### PR TITLE
[130] Add and initial version of a `Makefile` version and tiny test CI pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 130-add-initial-makefile-version-and-tiny-test-ci-pipeline
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test CI
+
+on:
+  push:
+    branches:
+      - main
+      - 130-add-initial-makefile-version-and-tiny-test-ci-pipeline
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Make
+        run: sudo apt-get install make
+
+      - name: Install dependencies and Build package
+        run: |
+          make install-ci
+
+      - name: Running the tests
+        run: |
+          make test-xmlcov

--- a/.gitignore
+++ b/.gitignore
@@ -103,7 +103,7 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,9 @@ test:
 .PHONY: test-htmlcov
 test-htmlcov:
 	@echo Running the tests with HTML coverage report ...
-	pytest --cov=chemotools .\tests -n="auto" --cov-report=html -x
+	pytest --cov=chemotools ./tests -n="auto" --cov-report=html -x
 
 .PHONY: test-xmlcov
 test-xmlcov:
 	@echo Running the tests with XML coverage report ...
-	pytest --cov=chemotools .\tests -n="auto" --cov-report=html -x
+	pytest --cov=chemotools ./tests -n="auto" --cov-report=html -x

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+# === Constants ===
+
+# the source directories which are being checked
+SRC_DIRS = ./chemotools ./tests
+
+# === Package and Dependencies ===
+
+# Upgrading pip, setuptools and wheel
+.PHONY: upgrade-pip
+upgrade-pip:
+	@echo Upgrading pip, setuptools and wheel ...
+	python -m pip install --upgrade pip setuptools wheel
+
+# Installing the required dependencies and building the package
+.PHONY: install
+install: upgrade-pip
+	@echo Installing the required dependencies and building the package ...
+	python -m pip install --upgrade . -r requirements.txt
+
+.PHONY: install-dev
+install-dev: upgrade-pip
+	@echo Installing the required dependencies and building the package for development ...
+	python -m pip install --upgrade . -r requirements.txt -r requirements-dev.txt
+
+.PHONY: install-ci
+install-ci: upgrade-pip
+	@echo Installing the required dependencies for CI ...
+	python -m pip install --upgrade . -r requirements.txt -r requirements-dev.txt
+
+# Building the package
+.PHONY: build
+build:
+	@echo Building the package ...
+	python -m build
+
+# === Source File Checks ===
+
+# Checking the source files with flake8
+.PHONY: lint-flake8
+lint-flake8:
+	@echo Checking the source files with flake8 ...
+	flake8 $(SRC_DIRS) --count --select=E9,F63,F7,F82 --show-source --statistics
+	flake8 $(SRC_DIRS) --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+# === Test Commands ===
+
+# Running a single test
+.PHONY: test
+test:
+	@echo Running specific test with pytest ...
+	pytest -k "$(TEST)" -x
+
+# Running the tests
+.PHONY: test-htmlcov
+test-htmlcov:
+	@echo Running the tests with HTML coverage report ...
+	pytest --cov=chemotools .\tests -n="auto" --cov-report=html -x
+
+.PHONY: test-xmlcov
+test-xmlcov:
+	@echo Running the tests with XML coverage report ...
+	pytest --cov=chemotools .\tests -n="auto" --cov-report=html -x

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Welcome to Chemotools, a Python package that integrates chemometrics with Scikit
 
 ## Note
 
-Since I released Chemotools, I have received a fantastic response from the community. I am really happy for the interest in the project 🤗. This also means that I have received a lot of good feedback and suggestions for improvements. I have been intensively working on releasing new versions of Chemotools to address the feedback and suggestions. If you use Chemotools, __make sure you are using the latest version__ (see installation), which will be aligned with the documentation. 
+Since I released Chemotools, I have received a fantastic response from the community. I am really happy for the interest in the project 🤗. This also means that I have received a lot of good feedback and suggestions for improvements. I have been intensively working on releasing new versions of Chemotools to address the feedback and suggestions. If you use Chemotools, __make sure you are using the latest version__ (see installation), which will be aligned with the documentation.
 
 👉👉 Check the [latest version](https://pypi.org/project/chemotools/) and make sure you don't miss out on cool new features.
 
@@ -63,12 +63,54 @@ from sklearn.pipeline import make_pipeline
 from chemotools.baseline import AirPls
 from chemotools.scatter import MultiplicativeScatterCorrection
 
-preprocessing = make_pipeline(AirPls(), MultiplicativeScatterCorrection(), StandardScaler(with_std=False)) 
+preprocessing = make_pipeline(AirPls(), MultiplicativeScatterCorrection(), StandardScaler(with_std=False))
 spectra_transformed = preprocessing.fit_transform(spectra)
 ```
 
 Check the [documentation](https://paucablop.github.io/chemotools/) for more information on how to use chemotools.
 
+## Development
+
+To install/update the package and its development dependencies, the following command can be used:
+
+```bash
+python -m pip install --upgrade . -r requirements.txt -r requirements-dev.txt
+```
+
+``chemotools`` also comes with a ``Makefile`` that provides shortcuts for common development tasks. The equivalent command to the one above would be:
+
+```bash
+make install-dev
+```
+
+Other useful commands include:
+
+- building the package:
+    ```bash
+    python -m build
+
+    # or using the Makefile
+    make build
+    ```
+
+- checking the linting of the package:
+    ```bash
+    flake8 ./chemotools ./tests --count --select=E9,F63,F7,F82 --show-source --statistics
+	flake8 ./chemotools ./tests --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+    # or using the Makefile
+    make lint-flake8
+    ```
+
+- parallelized testing the package with a coverage report:
+    ```bash
+    pytest --cov=chemotools .\tests -n="auto" --cov-report=html -x  # for an HTML report
+    pytest --cov=chemotools .\tests -n="auto" --cov-report=xml -x  # for an XML report
+
+    # or using the Makefile
+    make test-htmlcov
+    make test-xmlcov
+    ```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ Other useful commands include:
     make lint-flake8
     ```
 
+- testing only selected tests:
+    ```bash
+    pytest ./tests -k "test_load_coffee_pandas"
+
+    # or using the Makefile
+    make test TEST=test_load_coffee_pandas
+    ```
+
 - parallelized testing the package with a coverage report:
     ```bash
     pytest --cov=chemotools ./tests -n="auto" --cov-report=html -x  # for an HTML report

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ Other useful commands include:
 
 - parallelized testing the package with a coverage report:
     ```bash
-    pytest --cov=chemotools .\tests -n="auto" --cov-report=html -x  # for an HTML report
-    pytest --cov=chemotools .\tests -n="auto" --cov-report=xml -x  # for an XML report
+    pytest --cov=chemotools ./tests -n="auto" --cov-report=html -x  # for an HTML report
+    pytest --cov=chemotools ./tests -n="auto" --cov-report=xml -x  # for an XML report
 
     # or using the Makefile
     make test-htmlcov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+black
+build
+flake8
+isort[color]
+line_profiler
+matplotlib
+pytest
+pytest-cov
+pytest-xdist[psutil]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 black
 build
+coverage
 flake8
 isort[color]
 line_profiler


### PR DESCRIPTION
This pull request
- adds an initial version of a `Makefile` with basic commands, i.e., installation, build, lint checks, individual and parallelized testing (also mentioned in the new `Development` section of the ✍️ `README`)
- adds a tiny test CI pipeline that runs on every pull request and push on `main` ... so it should do now as well 😅 


Closes #130 
