### PR TITLE
250 feature add intensity conversion transformer

### DIFF
--- a/chemotools/physics/__init__.py
+++ b/chemotools/physics/__init__.py
@@ -1,0 +1,3 @@
+from ._intensity_conversion import IntensityConversion
+
+__all__ = ["IntensityConversion"]

--- a/chemotools/physics/_intensity_conversion.py
+++ b/chemotools/physics/_intensity_conversion.py
@@ -124,9 +124,11 @@ class IntensityConversion(TransformerMixin, OneToOneFeatureMixin, BaseEstimator)
     Examples
     --------
     >>> import numpy as np
-    >>> from chemotools.conversion import IntensityConversion
+    >>> from chemotools.physics import IntensityConversion
     >>> X = np.array([[0.0, 1.0, 2.0]])
-    >>> converter = IntensityConversion(input_unit="absorbance", output_unit="transmittance")
+    >>> converter = IntensityConversion(
+            input_unit="absorbance", output_unit="transmittance"
+        )
     IntensityConversion()
     >>> converter.fit_transform(X)
     array([[1.  , 0.1 , 0.01]])
@@ -170,7 +172,9 @@ class IntensityConversion(TransformerMixin, OneToOneFeatureMixin, BaseEstimator)
                 f"supported. Supported conversions are: {sorted(_VALID_CONVERSIONS)}."
             )
 
-        validate_data(self, X, y="no_validation", ensure_2d=True, reset=True, dtype=np.float64)
+        validate_data(
+            self, X, y="no_validation", ensure_2d=True, reset=True, dtype=np.float64
+        )
         return self
 
     def transform(self, X: np.ndarray, y=None) -> np.ndarray:

--- a/chemotools/physics/_intensity_conversion.py
+++ b/chemotools/physics/_intensity_conversion.py
@@ -1,0 +1,206 @@
+"""
+The :mod:`chemotools.physics._intensity_conversion` module implements
+an IntensityConversion transformer for spectral unit conversion.
+"""
+
+import warnings
+
+import numpy as np
+from sklearn.base import BaseEstimator, OneToOneFeatureMixin, TransformerMixin
+from sklearn.utils._param_validation import StrOptions
+from sklearn.utils.validation import check_is_fitted, validate_data
+
+_VALID_UNITS = frozenset(
+    {"absorbance", "transmittance", "kubelka_munk", "reflectance", "pseudoabsorbance"}
+)
+
+_VALID_CONVERSIONS = frozenset(
+    {
+        ("absorbance", "transmittance"),
+        ("transmittance", "absorbance"),
+        ("reflectance", "kubelka_munk"),
+        ("kubelka_munk", "reflectance"),
+        ("reflectance", "pseudoabsorbance"),
+        ("pseudoabsorbance", "reflectance"),
+    }
+)
+
+
+def _absorbance_to_transmittance(X: np.ndarray) -> np.ndarray:
+    return np.power(10.0, -X)
+
+
+def _transmittance_to_absorbance(X: np.ndarray) -> np.ndarray:
+    near_zero = X <= 0
+    if near_zero.any():
+        warnings.warn(
+            f"Transmittance values <= 0 found at indices "
+            f"{np.argwhere(near_zero).tolist()}. "
+            "These will produce inf or nan in the output.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return -np.log10(X)
+
+
+def _reflectance_to_kubelka_munk(X: np.ndarray) -> np.ndarray:
+    near_zero = X <= 0
+    if near_zero.any():
+        warnings.warn(
+            f"Reflectance values <= 0 found at indices "
+            f"{np.argwhere(near_zero).tolist()}. "
+            "These will produce inf or nan in the output.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return (1.0 - X) ** 2 / (2.0 * X)
+
+
+def _kubelka_munk_to_reflectance(X: np.ndarray) -> np.ndarray:
+    # Inverse of F(R) = (1-R)^2 / (2R): R = (1+F) - sqrt((1+F)^2 - 1)
+    return (1.0 + X) - np.sqrt((1.0 + X) ** 2 - 1.0)
+
+
+def _reflectance_to_pseudoabsorbance(X: np.ndarray) -> np.ndarray:
+    near_zero = X <= 0
+    if near_zero.any():
+        warnings.warn(
+            f"Reflectance values <= 0 found at indices "
+            f"{np.argwhere(near_zero).tolist()}. "
+            "These will produce inf or nan in the output.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return -np.log10(X)
+
+
+def _pseudoabsorbance_to_reflectance(X: np.ndarray) -> np.ndarray:
+    return np.power(10.0, -X)
+
+
+_CONVERSION_DISPATCH = {
+    ("absorbance", "transmittance"): _absorbance_to_transmittance,
+    ("transmittance", "absorbance"): _transmittance_to_absorbance,
+    ("reflectance", "kubelka_munk"): _reflectance_to_kubelka_munk,
+    ("kubelka_munk", "reflectance"): _kubelka_munk_to_reflectance,
+    ("reflectance", "pseudoabsorbance"): _reflectance_to_pseudoabsorbance,
+    ("pseudoabsorbance", "reflectance"): _pseudoabsorbance_to_reflectance,
+}
+
+
+class IntensityConversion(TransformerMixin, OneToOneFeatureMixin, BaseEstimator):
+    """
+    A transformer that converts spectral intensity data between common
+    measurement units used in vibrational and diffuse reflectance spectroscopy.
+
+    All ratio units (transmittance, reflectance) use the standard fraction
+    convention (0–1). Data in percent (0–100) must be divided by 100 before
+    using this transformer.
+
+    Parameters
+    ----------
+    input_unit : str, default="absorbance"
+        The unit of the input data. One of:
+        ``"absorbance"``, ``"transmittance"``, ``"reflectance"``,
+        ``"kubelka_munk"``, ``"pseudoabsorbance"``.
+
+    output_unit : str, default="transmittance"
+        The unit of the output data. One of:
+        ``"absorbance"``, ``"transmittance"``, ``"reflectance"``,
+        ``"kubelka_munk"``, ``"pseudoabsorbance"``.
+
+    Supported conversion pairs
+    --------------------------
+    - ``"absorbance"`` ↔ ``"transmittance"``: T = 10^(−A), A = −log₁₀(T)
+    - ``"reflectance"`` → ``"kubelka_munk"``: F(R) = (1−R)²/(2R)
+    - ``"kubelka_munk"`` → ``"reflectance"``: R = (1+F) − √((1+F)²−1)
+    - ``"reflectance"`` ↔ ``"pseudoabsorbance"``: PA = −log₁₀(R), R = 10^(−PA)
+
+    Attributes
+    ----------
+    n_features_in_ : int
+        The number of features in the input data.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from chemotools.conversion import IntensityConversion
+    >>> X = np.array([[0.0, 1.0, 2.0]])
+    >>> converter = IntensityConversion(input_unit="absorbance", output_unit="transmittance")
+    IntensityConversion()
+    >>> converter.fit_transform(X)
+    array([[1.  , 0.1 , 0.01]])
+    """
+
+    _parameter_constraints: dict = {
+        "input_unit": [StrOptions(_VALID_UNITS)],
+        "output_unit": [StrOptions(_VALID_UNITS)],
+    }
+
+    def __init__(
+        self,
+        input_unit: str = "absorbance",
+        output_unit: str = "transmittance",
+    ):
+        self.input_unit = input_unit
+        self.output_unit = output_unit
+
+    def fit(self, X: np.ndarray, y=None) -> "IntensityConversion":
+        """
+        Fit the transformer to the input data.
+
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_samples, n_features)
+            The input data to fit the transformer to.
+
+        y : None
+            Ignored to align with API.
+
+        Returns
+        -------
+        self : IntensityConversion
+            The fitted transformer.
+        """
+        self._validate_params()
+
+        if (self.input_unit, self.output_unit) not in _VALID_CONVERSIONS:
+            raise ValueError(
+                f"Conversion from '{self.input_unit}' to '{self.output_unit}' is not "
+                f"supported. Supported conversions are: {sorted(_VALID_CONVERSIONS)}."
+            )
+
+        validate_data(self, X, y="no_validation", ensure_2d=True, reset=True, dtype=np.float64)
+        return self
+
+    def transform(self, X: np.ndarray, y=None) -> np.ndarray:
+        """
+        Convert the input data to the target unit.
+
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_samples, n_features)
+            The input data to transform.
+
+        y : None
+            Ignored to align with API.
+
+        Returns
+        -------
+        X_converted : np.ndarray of shape (n_samples, n_features)
+            The converted data.
+        """
+        check_is_fitted(self, "n_features_in_")
+
+        X_ = validate_data(
+            self,
+            X,
+            y="no_validation",
+            ensure_2d=True,
+            copy=True,
+            reset=False,
+            dtype=np.float64,
+        )
+
+        conversion_fn = _CONVERSION_DISPATCH[(self.input_unit, self.output_unit)]
+        return conversion_fn(X_)

--- a/chemotools/physics/_intensity_conversion.py
+++ b/chemotools/physics/_intensity_conversion.py
@@ -58,6 +58,16 @@ def _reflectance_to_kubelka_munk(X: np.ndarray) -> np.ndarray:
 
 def _kubelka_munk_to_reflectance(X: np.ndarray) -> np.ndarray:
     # Inverse of F(R) = (1-R)^2 / (2R): R = (1+F) - sqrt((1+F)^2 - 1)
+    negative = X < 0
+    if negative.any():
+        warnings.warn(
+            f"Kubelka-Munk values < 0 found at indices "
+            f"{np.argwhere(negative).tolist()}. "
+            "These are non-physical and will produce nan in the output.",
+            UserWarning,
+            stacklevel=3,
+        )
+
     return (1.0 + X) - np.sqrt((1.0 + X) ** 2 - 1.0)
 
 

--- a/tests/physics/test_intensity_conversion.py
+++ b/tests/physics/test_intensity_conversion.py
@@ -4,14 +4,15 @@ from sklearn.utils.estimator_checks import check_estimator
 
 from chemotools.physics import IntensityConversion
 
-
 # --- sklearn compliance ---
+
 
 def test_compliance_intensity_conversion():
     check_estimator(IntensityConversion())
 
 
 # --- absorbance <-> transmittance ---
+
 
 def test_absorbance_to_transmittance_zero():
     X = np.array([[0.0, 0.0]])
@@ -46,6 +47,7 @@ def test_absorbance_transmittance_round_trip():
 
 # --- reflectance <-> kubelka_munk ---
 
+
 def test_reflectance_to_kubelka_munk_one():
     X = np.array([[1.0]])
     result = IntensityConversion("reflectance", "kubelka_munk").fit_transform(X)
@@ -72,6 +74,7 @@ def test_reflectance_kubelka_munk_round_trip():
 
 
 # --- reflectance <-> pseudoabsorbance ---
+
 
 def test_reflectance_to_pseudoabsorbance_one():
     X = np.array([[1.0]])
@@ -100,11 +103,14 @@ def test_pseudoabsorbance_to_reflectance_one():
 def test_reflectance_pseudoabsorbance_round_trip():
     X_R = np.array([[0.1, 0.5, 0.9]])
     X_PA = IntensityConversion("reflectance", "pseudoabsorbance").fit_transform(X_R)
-    X_R_back = IntensityConversion("pseudoabsorbance", "reflectance").fit_transform(X_PA)
+    X_R_back = IntensityConversion("pseudoabsorbance", "reflectance").fit_transform(
+        X_PA
+    )
     assert np.allclose(X_R, X_R_back, atol=1e-10)
 
 
 # --- multiple samples ---
+
 
 def test_multiple_samples_absorbance_to_transmittance():
     X = np.array([[0.0], [1.0], [2.0]])
@@ -114,6 +120,7 @@ def test_multiple_samples_absorbance_to_transmittance():
 
 
 # --- validation errors ---
+
 
 def test_unsupported_conversion_raises():
     t = IntensityConversion(input_unit="absorbance", output_unit="reflectance")
@@ -134,6 +141,7 @@ def test_invalid_output_unit_raises():
 
 
 # --- numerical edge case warnings ---
+
 
 def test_zero_transmittance_warns():
     X = np.array([[0.0, 0.5]])

--- a/tests/physics/test_intensity_conversion.py
+++ b/tests/physics/test_intensity_conversion.py
@@ -249,6 +249,18 @@ class TestEdgeCases:
         with pytest.warns(UserWarning):
             t.transform(X)
 
+    def test_zero_kubelka_munk_reflectance_warns(self):
+        """
+        Test that zero reflectance values warn during inverse Kubelka-Munk conversion.
+        """
+        # Arrange
+        X = np.array([[-0.1, 0.0, 0.5]])
+        t = IntensityConversion("kubelka_munk", "reflectance").fit(X)
+
+        # Act & Assert
+        with pytest.warns(UserWarning):
+            t.transform(X)
+
     def test_zero_reflectance_pseudoabsorbance_warns(self):
         """Test that zero reflectance values warn during pseudoabsorbance conversion."""
         # Arrange

--- a/tests/physics/test_intensity_conversion.py
+++ b/tests/physics/test_intensity_conversion.py
@@ -4,161 +4,257 @@ from sklearn.utils.estimator_checks import check_estimator
 
 from chemotools.physics import IntensityConversion
 
-# --- sklearn compliance ---
 
-
+# Test compliance with scikit-learn
 def test_compliance_intensity_conversion():
-    check_estimator(IntensityConversion())
+    """Test compliance with scikit-learn estimator interface."""
+    # Arrange
+    transformer = IntensityConversion()
+    # Act & Assert
+    check_estimator(transformer)
 
 
-# --- absorbance <-> transmittance ---
+# Test functionality
+class TestAbsorbanceTransmittance:
+    def test_absorbance_to_transmittance_zero(self):
+        """Test that zero absorbance converts to transmittance of one."""
+        # Arrange
+        X = np.array([[0.0, 0.0]])
+
+        # Act
+        result = IntensityConversion("absorbance", "transmittance").fit_transform(X)
+
+        # Assert
+        assert np.allclose(result, [[1.0, 1.0]], atol=1e-10)
+
+    def test_absorbance_to_transmittance_known_values(self):
+        """Test absorbance to transmittance conversion with known values."""
+        # Arrange
+        X = np.array([[1.0, 2.0]])
+
+        # Act
+        result = IntensityConversion("absorbance", "transmittance").fit_transform(X)
+
+        # Assert
+        assert np.allclose(result, [[0.1, 0.01]], atol=1e-10)
+
+    def test_transmittance_to_absorbance_one(self):
+        """Test that transmittance of one converts to absorbance of zero."""
+        # Arrange
+        X = np.array([[1.0]])
+
+        # Act
+        result = IntensityConversion("transmittance", "absorbance").fit_transform(X)
+
+        # Assert
+        assert np.allclose(result, [[0.0]], atol=1e-10)
+
+    def test_transmittance_to_absorbance_known_values(self):
+        """Test transmittance to absorbance conversion with known values."""
+        # Arrange
+        X = np.array([[0.1, 0.01]])
+
+        # Act
+        result = IntensityConversion("transmittance", "absorbance").fit_transform(X)
+
+        # Assert
+        assert np.allclose(result, [[1.0, 2.0]], atol=1e-10)
+
+    def test_absorbance_transmittance_round_trip(self):
+        """Test that absorbance -> transmittance -> absorbance is lossless."""
+        # Arrange
+        X_A = np.array([[0.5, 1.0, 1.5]])
+
+        # Act
+        X_T = IntensityConversion("absorbance", "transmittance").fit_transform(X_A)
+        X_A_back = IntensityConversion("transmittance", "absorbance").fit_transform(X_T)
+
+        # Assert
+        assert np.allclose(X_A, X_A_back, atol=1e-10)
 
 
-def test_absorbance_to_transmittance_zero():
-    X = np.array([[0.0, 0.0]])
-    result = IntensityConversion("absorbance", "transmittance").fit_transform(X)
-    assert np.allclose(result, [[1.0, 1.0]], atol=1e-10)
+class TestReflectanceKubelkaMunk:
+    def test_reflectance_to_kubelka_munk_one(self):
+        """Test that reflectance of one converts to Kubelka-Munk of zero."""
+        # Arrange
+        X = np.array([[1.0]])
+
+        # Act
+        result = IntensityConversion("reflectance", "kubelka_munk").fit_transform(X)
+
+        # Assert
+        assert np.allclose(result, [[0.0]], atol=1e-10)
+
+    def test_reflectance_to_kubelka_munk_half(self):
+        """Test reflectance of 0.5 converts to expected Kubelka-Munk value."""
+        # Arrange
+        X = np.array([[0.5]])
+
+        # Act
+        result = IntensityConversion("reflectance", "kubelka_munk").fit_transform(X)
+
+        # Assert
+        assert np.allclose(result, [[0.25]], atol=1e-10)
+
+    def test_kubelka_munk_to_reflectance_zero(self):
+        """Test that Kubelka-Munk of zero converts to reflectance of one."""
+        # Arrange
+        X = np.array([[0.0]])
+
+        # Act
+        result = IntensityConversion("kubelka_munk", "reflectance").fit_transform(X)
+
+        # Assert
+        assert np.allclose(result, [[1.0]], atol=1e-10)
+
+    def test_reflectance_kubelka_munk_round_trip(self):
+        """Test that reflectance -> Kubelka-Munk -> reflectance is lossless."""
+        # Arrange
+        X_R = np.array([[0.1, 0.5, 0.9]])
+
+        # Act
+        X_KM = IntensityConversion("reflectance", "kubelka_munk").fit_transform(X_R)
+        X_R_back = IntensityConversion("kubelka_munk", "reflectance").fit_transform(
+            X_KM
+        )
+
+        # Assert
+        assert np.allclose(X_R, X_R_back, atol=1e-10)
 
 
-def test_absorbance_to_transmittance_known_values():
-    X = np.array([[1.0, 2.0]])
-    result = IntensityConversion("absorbance", "transmittance").fit_transform(X)
-    assert np.allclose(result, [[0.1, 0.01]], atol=1e-10)
+class TestReflectancePseudoAbsorbance:
+    def test_reflectance_to_pseudoabsorbance_one(self):
+        """Test that reflectance of one converts to pseudoabsorbance of zero."""
+        # Arrange
+        X = np.array([[1.0]])
+
+        # Act
+        result = IntensityConversion("reflectance", "pseudoabsorbance").fit_transform(X)
+
+        # Assert
+        assert np.allclose(result, [[0.0]], atol=1e-10)
+
+    def test_reflectance_to_pseudoabsorbance_known_values(self):
+        """Test reflectance to pseudoabsorbance conversion with known values."""
+        # Arrange
+        X = np.array([[0.1]])
+
+        # Act
+        result = IntensityConversion("reflectance", "pseudoabsorbance").fit_transform(X)
+
+        # Assert
+        assert np.allclose(result, [[1.0]], atol=1e-10)
+
+    def test_pseudoabsorbance_to_reflectance_zero(self):
+        """Test that pseudoabsorbance of zero converts to reflectance of one."""
+        # Arrange
+        X = np.array([[0.0]])
+
+        # Act
+        result = IntensityConversion("pseudoabsorbance", "reflectance").fit_transform(X)
+
+        # Assert
+        assert np.allclose(result, [[1.0]], atol=1e-10)
+
+    def test_pseudoabsorbance_to_reflectance_one(self):
+        """Test pseudoabsorbance to reflectance conversion with known values."""
+        # Arrange
+        X = np.array([[1.0]])
+
+        # Act
+        result = IntensityConversion("pseudoabsorbance", "reflectance").fit_transform(X)
+
+        # Assert
+        assert np.allclose(result, [[0.1]], atol=1e-10)
+
+    def test_reflectance_pseudoabsorbance_round_trip(self):
+        """Test that reflectance -> pseudoabsorbance -> reflectance is lossless."""
+        # Arrange
+        X_R = np.array([[0.1, 0.5, 0.9]])
+
+        # Act
+        X_PA = IntensityConversion("reflectance", "pseudoabsorbance").fit_transform(X_R)
+        X_R_back = IntensityConversion("pseudoabsorbance", "reflectance").fit_transform(
+            X_PA
+        )
+
+        # Assert
+        assert np.allclose(X_R, X_R_back, atol=1e-10)
 
 
-def test_transmittance_to_absorbance_one():
-    X = np.array([[1.0]])
-    result = IntensityConversion("transmittance", "absorbance").fit_transform(X)
-    assert np.allclose(result, [[0.0]], atol=1e-10)
+class TestMultiSamples:
+    def test_multiple_samples_absorbance_to_transmittance(self):
+        """Test absorbance to transmittance conversion with multiple samples."""
+        # Arrange
+        X = np.array([[0.0], [1.0], [2.0]])
+        expected = np.array([[1.0], [0.1], [0.01]])
+
+        # Act
+        result = IntensityConversion("absorbance", "transmittance").fit_transform(X)
+
+        # Assert
+        assert np.allclose(result, expected, atol=1e-10)
 
 
-def test_transmittance_to_absorbance_known_values():
-    X = np.array([[0.1, 0.01]])
-    result = IntensityConversion("transmittance", "absorbance").fit_transform(X)
-    assert np.allclose(result, [[1.0, 2.0]], atol=1e-10)
+class TestValidationErrors:
+    def test_unsupported_conversion_raises(self):
+        """Test that an unsupported conversion pair raises a ValueError."""
+        # Arrange
+        t = IntensityConversion(input_unit="absorbance", output_unit="reflectance")
+        X = np.array([[1.0, 2.0]])
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="not supported"):
+            t.fit(X)
+
+    def test_invalid_input_unit_raises(self):
+        """Test that an invalid input unit raises a ValueError."""
+        # Arrange
+        t = IntensityConversion(input_unit="banana", output_unit="transmittance")
+        X = np.array([[1.0]])
+
+        # Act & Assert
+        with pytest.raises(ValueError):
+            t.fit(X)
+
+    def test_invalid_output_unit_raises(self):
+        """Test that an invalid output unit raises a ValueError."""
+        # Arrange
+        t = IntensityConversion(input_unit="absorbance", output_unit="banana")
+        X = np.array([[1.0]])
+
+        # Act & Assert
+        with pytest.raises(ValueError):
+            t.fit(X)
 
 
-def test_absorbance_transmittance_round_trip():
-    X_A = np.array([[0.5, 1.0, 1.5]])
-    X_T = IntensityConversion("absorbance", "transmittance").fit_transform(X_A)
-    X_A_back = IntensityConversion("transmittance", "absorbance").fit_transform(X_T)
-    assert np.allclose(X_A, X_A_back, atol=1e-10)
+class TestEdgeCases:
+    def test_zero_transmittance_warns(self):
+        """Test that zero transmittance values trigger a UserWarning."""
+        # Arrange
+        X = np.array([[0.0, 0.5]])
+        t = IntensityConversion("transmittance", "absorbance").fit(X)
 
+        # Act & Assert
+        with pytest.warns(UserWarning):
+            t.transform(X)
 
-# --- reflectance <-> kubelka_munk ---
+    def test_zero_reflectance_kubelka_munk_warns(self):
+        """Test that zero reflectance values warn during Kubelka-Munk conversion."""
+        # Arrange
+        X = np.array([[0.0, 0.5]])
+        t = IntensityConversion("reflectance", "kubelka_munk").fit(X)
 
+        # Act & Assert
+        with pytest.warns(UserWarning):
+            t.transform(X)
 
-def test_reflectance_to_kubelka_munk_one():
-    X = np.array([[1.0]])
-    result = IntensityConversion("reflectance", "kubelka_munk").fit_transform(X)
-    assert np.allclose(result, [[0.0]], atol=1e-10)
+    def test_zero_reflectance_pseudoabsorbance_warns(self):
+        """Test that zero reflectance values warn during pseudoabsorbance conversion."""
+        # Arrange
+        X = np.array([[0.0, 0.5]])
+        t = IntensityConversion("reflectance", "pseudoabsorbance").fit(X)
 
-
-def test_reflectance_to_kubelka_munk_half():
-    X = np.array([[0.5]])
-    result = IntensityConversion("reflectance", "kubelka_munk").fit_transform(X)
-    assert np.allclose(result, [[0.25]], atol=1e-10)
-
-
-def test_kubelka_munk_to_reflectance_zero():
-    X = np.array([[0.0]])
-    result = IntensityConversion("kubelka_munk", "reflectance").fit_transform(X)
-    assert np.allclose(result, [[1.0]], atol=1e-10)
-
-
-def test_reflectance_kubelka_munk_round_trip():
-    X_R = np.array([[0.1, 0.5, 0.9]])
-    X_KM = IntensityConversion("reflectance", "kubelka_munk").fit_transform(X_R)
-    X_R_back = IntensityConversion("kubelka_munk", "reflectance").fit_transform(X_KM)
-    assert np.allclose(X_R, X_R_back, atol=1e-10)
-
-
-# --- reflectance <-> pseudoabsorbance ---
-
-
-def test_reflectance_to_pseudoabsorbance_one():
-    X = np.array([[1.0]])
-    result = IntensityConversion("reflectance", "pseudoabsorbance").fit_transform(X)
-    assert np.allclose(result, [[0.0]], atol=1e-10)
-
-
-def test_reflectance_to_pseudoabsorbance_known_values():
-    X = np.array([[0.1]])
-    result = IntensityConversion("reflectance", "pseudoabsorbance").fit_transform(X)
-    assert np.allclose(result, [[1.0]], atol=1e-10)
-
-
-def test_pseudoabsorbance_to_reflectance_zero():
-    X = np.array([[0.0]])
-    result = IntensityConversion("pseudoabsorbance", "reflectance").fit_transform(X)
-    assert np.allclose(result, [[1.0]], atol=1e-10)
-
-
-def test_pseudoabsorbance_to_reflectance_one():
-    X = np.array([[1.0]])
-    result = IntensityConversion("pseudoabsorbance", "reflectance").fit_transform(X)
-    assert np.allclose(result, [[0.1]], atol=1e-10)
-
-
-def test_reflectance_pseudoabsorbance_round_trip():
-    X_R = np.array([[0.1, 0.5, 0.9]])
-    X_PA = IntensityConversion("reflectance", "pseudoabsorbance").fit_transform(X_R)
-    X_R_back = IntensityConversion("pseudoabsorbance", "reflectance").fit_transform(
-        X_PA
-    )
-    assert np.allclose(X_R, X_R_back, atol=1e-10)
-
-
-# --- multiple samples ---
-
-
-def test_multiple_samples_absorbance_to_transmittance():
-    X = np.array([[0.0], [1.0], [2.0]])
-    result = IntensityConversion("absorbance", "transmittance").fit_transform(X)
-    expected = np.array([[1.0], [0.1], [0.01]])
-    assert np.allclose(result, expected, atol=1e-10)
-
-
-# --- validation errors ---
-
-
-def test_unsupported_conversion_raises():
-    t = IntensityConversion(input_unit="absorbance", output_unit="reflectance")
-    with pytest.raises(ValueError, match="not supported"):
-        t.fit(np.array([[1.0, 2.0]]))
-
-
-def test_invalid_input_unit_raises():
-    t = IntensityConversion(input_unit="banana", output_unit="transmittance")
-    with pytest.raises(ValueError):
-        t.fit(np.array([[1.0]]))
-
-
-def test_invalid_output_unit_raises():
-    t = IntensityConversion(input_unit="absorbance", output_unit="banana")
-    with pytest.raises(ValueError):
-        t.fit(np.array([[1.0]]))
-
-
-# --- numerical edge case warnings ---
-
-
-def test_zero_transmittance_warns():
-    X = np.array([[0.0, 0.5]])
-    t = IntensityConversion("transmittance", "absorbance").fit(X)
-    with pytest.warns(UserWarning):
-        t.transform(X)
-
-
-def test_zero_reflectance_kubelka_munk_warns():
-    X = np.array([[0.0, 0.5]])
-    t = IntensityConversion("reflectance", "kubelka_munk").fit(X)
-    with pytest.warns(UserWarning):
-        t.transform(X)
-
-
-def test_zero_reflectance_pseudoabsorbance_warns():
-    X = np.array([[0.0, 0.5]])
-    t = IntensityConversion("reflectance", "pseudoabsorbance").fit(X)
-    with pytest.warns(UserWarning):
-        t.transform(X)
+        # Act & Assert
+        with pytest.warns(UserWarning):
+            t.transform(X)

--- a/tests/physics/test_intensity_conversion.py
+++ b/tests/physics/test_intensity_conversion.py
@@ -1,0 +1,156 @@
+import numpy as np
+import pytest
+from sklearn.utils.estimator_checks import check_estimator
+
+from chemotools.physics import IntensityConversion
+
+
+# --- sklearn compliance ---
+
+def test_compliance_intensity_conversion():
+    check_estimator(IntensityConversion())
+
+
+# --- absorbance <-> transmittance ---
+
+def test_absorbance_to_transmittance_zero():
+    X = np.array([[0.0, 0.0]])
+    result = IntensityConversion("absorbance", "transmittance").fit_transform(X)
+    assert np.allclose(result, [[1.0, 1.0]], atol=1e-10)
+
+
+def test_absorbance_to_transmittance_known_values():
+    X = np.array([[1.0, 2.0]])
+    result = IntensityConversion("absorbance", "transmittance").fit_transform(X)
+    assert np.allclose(result, [[0.1, 0.01]], atol=1e-10)
+
+
+def test_transmittance_to_absorbance_one():
+    X = np.array([[1.0]])
+    result = IntensityConversion("transmittance", "absorbance").fit_transform(X)
+    assert np.allclose(result, [[0.0]], atol=1e-10)
+
+
+def test_transmittance_to_absorbance_known_values():
+    X = np.array([[0.1, 0.01]])
+    result = IntensityConversion("transmittance", "absorbance").fit_transform(X)
+    assert np.allclose(result, [[1.0, 2.0]], atol=1e-10)
+
+
+def test_absorbance_transmittance_round_trip():
+    X_A = np.array([[0.5, 1.0, 1.5]])
+    X_T = IntensityConversion("absorbance", "transmittance").fit_transform(X_A)
+    X_A_back = IntensityConversion("transmittance", "absorbance").fit_transform(X_T)
+    assert np.allclose(X_A, X_A_back, atol=1e-10)
+
+
+# --- reflectance <-> kubelka_munk ---
+
+def test_reflectance_to_kubelka_munk_one():
+    X = np.array([[1.0]])
+    result = IntensityConversion("reflectance", "kubelka_munk").fit_transform(X)
+    assert np.allclose(result, [[0.0]], atol=1e-10)
+
+
+def test_reflectance_to_kubelka_munk_half():
+    X = np.array([[0.5]])
+    result = IntensityConversion("reflectance", "kubelka_munk").fit_transform(X)
+    assert np.allclose(result, [[0.25]], atol=1e-10)
+
+
+def test_kubelka_munk_to_reflectance_zero():
+    X = np.array([[0.0]])
+    result = IntensityConversion("kubelka_munk", "reflectance").fit_transform(X)
+    assert np.allclose(result, [[1.0]], atol=1e-10)
+
+
+def test_reflectance_kubelka_munk_round_trip():
+    X_R = np.array([[0.1, 0.5, 0.9]])
+    X_KM = IntensityConversion("reflectance", "kubelka_munk").fit_transform(X_R)
+    X_R_back = IntensityConversion("kubelka_munk", "reflectance").fit_transform(X_KM)
+    assert np.allclose(X_R, X_R_back, atol=1e-10)
+
+
+# --- reflectance <-> pseudoabsorbance ---
+
+def test_reflectance_to_pseudoabsorbance_one():
+    X = np.array([[1.0]])
+    result = IntensityConversion("reflectance", "pseudoabsorbance").fit_transform(X)
+    assert np.allclose(result, [[0.0]], atol=1e-10)
+
+
+def test_reflectance_to_pseudoabsorbance_known_values():
+    X = np.array([[0.1]])
+    result = IntensityConversion("reflectance", "pseudoabsorbance").fit_transform(X)
+    assert np.allclose(result, [[1.0]], atol=1e-10)
+
+
+def test_pseudoabsorbance_to_reflectance_zero():
+    X = np.array([[0.0]])
+    result = IntensityConversion("pseudoabsorbance", "reflectance").fit_transform(X)
+    assert np.allclose(result, [[1.0]], atol=1e-10)
+
+
+def test_pseudoabsorbance_to_reflectance_one():
+    X = np.array([[1.0]])
+    result = IntensityConversion("pseudoabsorbance", "reflectance").fit_transform(X)
+    assert np.allclose(result, [[0.1]], atol=1e-10)
+
+
+def test_reflectance_pseudoabsorbance_round_trip():
+    X_R = np.array([[0.1, 0.5, 0.9]])
+    X_PA = IntensityConversion("reflectance", "pseudoabsorbance").fit_transform(X_R)
+    X_R_back = IntensityConversion("pseudoabsorbance", "reflectance").fit_transform(X_PA)
+    assert np.allclose(X_R, X_R_back, atol=1e-10)
+
+
+# --- multiple samples ---
+
+def test_multiple_samples_absorbance_to_transmittance():
+    X = np.array([[0.0], [1.0], [2.0]])
+    result = IntensityConversion("absorbance", "transmittance").fit_transform(X)
+    expected = np.array([[1.0], [0.1], [0.01]])
+    assert np.allclose(result, expected, atol=1e-10)
+
+
+# --- validation errors ---
+
+def test_unsupported_conversion_raises():
+    t = IntensityConversion(input_unit="absorbance", output_unit="reflectance")
+    with pytest.raises(ValueError, match="not supported"):
+        t.fit(np.array([[1.0, 2.0]]))
+
+
+def test_invalid_input_unit_raises():
+    t = IntensityConversion(input_unit="banana", output_unit="transmittance")
+    with pytest.raises(ValueError):
+        t.fit(np.array([[1.0]]))
+
+
+def test_invalid_output_unit_raises():
+    t = IntensityConversion(input_unit="absorbance", output_unit="banana")
+    with pytest.raises(ValueError):
+        t.fit(np.array([[1.0]]))
+
+
+# --- numerical edge case warnings ---
+
+def test_zero_transmittance_warns():
+    X = np.array([[0.0, 0.5]])
+    t = IntensityConversion("transmittance", "absorbance").fit(X)
+    with pytest.warns(UserWarning):
+        t.transform(X)
+
+
+def test_zero_reflectance_kubelka_munk_warns():
+    X = np.array([[0.0, 0.5]])
+    t = IntensityConversion("reflectance", "kubelka_munk").fit(X)
+    with pytest.warns(UserWarning):
+        t.transform(X)
+
+
+def test_zero_reflectance_pseudoabsorbance_warns():
+    X = np.array([[0.0, 0.5]])
+    t = IntensityConversion("reflectance", "pseudoabsorbance").fit(X)
+    with pytest.warns(UserWarning):
+        t.transform(X)


### PR DESCRIPTION
## Sumary

Spectroscopists routinely need to convert between intensity representations before applying chemometric models (e.g., NIR instruments often record transmittance or reflectance, while models may expect absorbance or Kubelka-Munk units). Until now, users had to apply these conversions manually outside the pipeline, breaking sklearn's `Pipeline` / `GridSearchCV` composability.

`IntensityConversion` brings these conversions into the transformer API so they can be inserted as a pipeline step, versioned with the model, and validated automatically via `check_estimator`.

This pull request implements:
- Adds a new `chemotools.physics` subpackage with an `IntensityConversion` sklearn-compatible transformer.
- Supports six spectral unit conversions:  absorbance ↔ transmittance, reflectance ↔ Kubelka-Munk, and reflectance ↔ pseudoabsorbance.
- Emits `UserWarning` on physically invalid inputs (zero transmittance/reflectance) instead of silently producing `inf`/`nan`

closes #250 