### PR TITLE
Add RubberbandCorrection baseline transformer

### DIFF
--- a/chemotools/baseline/__init__.py
+++ b/chemotools/baseline/__init__.py
@@ -6,6 +6,7 @@ from ._cubic_spline_correction import CubicSplineCorrection
 from ._linear_correction import LinearCorrection
 from ._non_negative import NonNegative
 from ._polynomial_correction import PolynomialCorrection
+from ._rubberband_correction import RubberbandCorrection
 from ._subtract_reference import SubtractReference
 
 __all__ = [
@@ -17,5 +18,6 @@ __all__ = [
     "LinearCorrection",
     "NonNegative",
     "PolynomialCorrection",
+    "RubberbandCorrection",
     "SubtractReference",
 ]

--- a/chemotools/baseline/_rubberband_correction.py
+++ b/chemotools/baseline/_rubberband_correction.py
@@ -1,0 +1,154 @@
+"""
+The :mod:`chemotools.baseline._rubberband_correction` module implements
+a rubberband baseline correction transformer.
+"""
+
+# Author: Lasse Skjoldborg Krog
+# License: MIT
+
+import numpy as np
+from sklearn.base import BaseEstimator, OneToOneFeatureMixin, TransformerMixin
+from sklearn.utils.validation import check_is_fitted, validate_data
+
+from chemotools._doc_mixin import DocLinkMixin
+
+
+class RubberbandCorrection(
+    DocLinkMixin, TransformerMixin, OneToOneFeatureMixin, BaseEstimator
+):
+    """
+    A transformer that removes a baseline using the rubberband method.
+
+    The rubberband baseline is the lower convex hull of the spectrum — the
+    set of straight-line segments a rubber band would form if stretched
+    along the underside of the spectrum. The baseline is subtracted from
+    each spectrum, leaving the peaks resting on a flat zero background.
+
+    The lower convex hull is computed with Andrew's monotone chain
+    algorithm [1]_ [2]_ in feature-index space, so the feature axis
+    (e.g. wavenumbers) is assumed to be sorted; even spacing is not required.
+    The method has no parameters.
+
+    Attributes
+    ----------
+    n_features_in_ : int
+        The number of features in the input data.
+
+    References
+    ----------
+    .. [1] A. M. Andrew, "Another efficient algorithm for convex hulls in two
+       dimensions", Information Processing Letters, 9(5), 216-219, 1979.
+    .. [2] Monotone chain convex hull, reference implementation:
+       https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain
+
+    Examples
+    --------
+    >>> from chemotools.baseline import RubberbandCorrection
+    >>> from chemotools.datasets import load_fermentation_train
+    >>> # Load sample data
+    >>> X, _ = load_fermentation_train()
+    >>> # Instantiate the transformer
+    >>> transformer = RubberbandCorrection()
+    RubberbandCorrection()
+    >>> transformer.fit(X)
+    >>> # Generate baseline-corrected data
+    >>> X_corrected = transformer.transform(X)
+    """
+
+    _parameter_constraints: dict = {}
+
+    def fit(self, X: np.ndarray, y=None) -> "RubberbandCorrection":
+        """
+        Fit the transformer to the input data.
+
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_samples, n_features)
+            The input data to fit the transformer to.
+
+        y : None
+            Ignored to align with API.
+
+        Returns
+        -------
+        self : RubberbandCorrection
+            The fitted transformer.
+        """
+        # Validate the input parameters
+        self._validate_params()
+
+        # Check that X is a 2D array and has only finite values
+        X = validate_data(
+            self, X, y="no_validation", ensure_2d=True, reset=True, dtype=np.float64
+        )
+
+        return self
+
+    def transform(self, X: np.ndarray, y=None) -> np.ndarray:
+        """
+        Transform the input data by subtracting the rubberband baseline.
+
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_samples, n_features)
+            The input data to transform.
+
+        y : None
+            Ignored to align with API.
+
+        Returns
+        -------
+        X_transformed : np.ndarray of shape (n_samples, n_features)
+            The baseline-corrected data.
+        """
+        # Check that the estimator is fitted
+        check_is_fitted(self, "n_features_in_")
+
+        # Check that X is a 2D array and has only finite values
+        X_ = validate_data(
+            self,
+            X,
+            y="no_validation",
+            ensure_2d=True,
+            copy=True,
+            reset=False,
+            dtype=np.float64,
+        )
+
+        # Subtract the rubberband baseline from each spectrum
+        for i, x in enumerate(X_):
+            X_[i] = x - self._rubberband_baseline(x)
+
+        return X_.reshape(-1, 1) if X_.ndim == 1 else X_
+
+    @staticmethod
+    def _rubberband_baseline(x: np.ndarray) -> np.ndarray:
+        """Return the rubberband (lower convex hull) baseline of one spectrum.
+
+        The lower convex hull is found with Andrew's monotone chain
+        algorithm and linearly interpolated back onto every feature index.
+
+        See the ``References`` section of the class docstring for the
+        algorithm source.
+        """
+        n = x.size
+
+        # Andrew's monotone chain — lower hull only. Reference implementation:
+        # https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain
+        lower: list[tuple[int, float]] = []
+        for i in range(n):
+            point = (i, float(x[i]))
+            while len(lower) >= 2:
+                o, a = lower[-2], lower[-1]
+                cross = (a[0] - o[0]) * (point[1] - o[1]) - (a[1] - o[1]) * (
+                    point[0] - o[0]
+                )
+                if cross <= 0:
+                    lower.pop()
+                else:
+                    break
+            lower.append(point)
+
+        hull_idx = np.array([p[0] for p in lower])
+        hull_val = np.array([p[1] for p in lower])
+        return np.interp(np.arange(n), hull_idx, hull_val)

--- a/docs/source/api/baseline.rst
+++ b/docs/source/api/baseline.rst
@@ -18,6 +18,7 @@ Baseline correction methods for spectral preprocessing. These methods remove bas
        LinearCorrection,
        NonNegative,
        PolynomialCorrection,
+       RubberbandCorrection,
        SubtractReference,
    )
 
@@ -46,6 +47,8 @@ Available Classes
      - Enforce non-negative values
    * - :doc:`PolynomialCorrection </methods/generated/chemotools.baseline.PolynomialCorrection>`
      - Polynomial baseline fitting and subtraction
+   * - :doc:`RubberbandCorrection </methods/generated/chemotools.baseline.RubberbandCorrection>`
+     - Rubberband (convex hull) baseline correction
    * - :doc:`SubtractReference </methods/generated/chemotools.baseline.SubtractReference>`
      - Subtract a reference spectrum
 

--- a/docs/source/methods/baseline.rst
+++ b/docs/source/methods/baseline.rst
@@ -15,6 +15,7 @@ Baseline Methods
     LinearCorrection
     NonNegative
     PolynomialCorrection
+    RubberbandCorrection
     SubtractReference
 
 

--- a/tests/baseline/test_rubberband_correction.py
+++ b/tests/baseline/test_rubberband_correction.py
@@ -1,0 +1,79 @@
+"""Tests for :class:`chemotools.baseline.RubberbandCorrection`."""
+
+import numpy as np
+from numpy.testing import assert_allclose
+from sklearn.utils.estimator_checks import check_estimator
+
+from chemotools.baseline import RubberbandCorrection
+
+
+# Test compliance with scikit-learn
+def test_compliance_rubberband():
+    # Arrange
+    transformer = RubberbandCorrection()
+    # Act & Assert
+    check_estimator(transformer)
+
+
+# Test functionality: a known spectrum gives a known baseline-corrected result
+def test_rubberband_known_correction():
+    # Arrange
+    rubberband = RubberbandCorrection()
+    spectrum = np.array([[0.0, 1.0, 10.0, 3.0, 4.0]])
+    # The lower convex hull is the straight line through the first and last
+    # points ([0, 1, 2, 3, 4]); subtracting it leaves only the single peak.
+    expected = np.array([[0.0, 0.0, 8.0, 0.0, 0.0]])
+
+    # Act
+    corrected = rubberband.fit_transform(spectrum)
+
+    # Assert
+    assert_allclose(corrected, expected)
+
+
+# Test functionality: a spectrum that is already linear collapses to zero
+def test_rubberband_linear_spectrum_becomes_zero():
+    # Arrange
+    rubberband = RubberbandCorrection()
+    spectrum = np.array([[1.0, 2.0, 3.0, 4.0, 5.0]])
+
+    # Act
+    corrected = rubberband.fit_transform(spectrum)
+
+    # Assert
+    assert_allclose(corrected, np.zeros_like(spectrum), atol=1e-12)
+
+
+# Test functionality: peaks rest on a flat, non-negative, zero background
+def test_rubberband_endpoints_and_nonnegativity():
+    # Arrange
+    rubberband = RubberbandCorrection()
+    feature_axis = np.linspace(0, 1, 200)
+    sloped_baseline = 5.0 + 3.0 * feature_axis
+    peak = 10.0 * np.exp(-((feature_axis - 0.5) ** 2) / 0.001)
+    spectrum = (sloped_baseline + peak).reshape(1, -1)
+
+    # Act
+    corrected = rubberband.fit_transform(spectrum)
+
+    # Assert
+    assert corrected.shape == spectrum.shape
+    assert_allclose(corrected[0, [0, -1]], [0.0, 0.0], atol=1e-9)
+    assert np.all(corrected >= -1e-9)
+    assert np.isclose(corrected.min(), 0.0, atol=1e-9)
+
+
+# Test functionality: each spectrum in a batch is corrected independently
+def test_rubberband_batch_is_row_wise():
+    # Arrange
+    rubberband = RubberbandCorrection()
+    spectrum_a = np.array([0.0, 1.0, 10.0, 3.0, 4.0])
+    spectrum_b = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    batch = np.vstack([spectrum_a, spectrum_b])
+
+    # Act
+    corrected = rubberband.fit_transform(batch)
+
+    # Assert
+    assert_allclose(corrected[0], [0.0, 0.0, 8.0, 0.0, 0.0])
+    assert_allclose(corrected[1], np.zeros(5), atol=1e-12)


### PR DESCRIPTION
## Summary

- Add `RubberbandCorrection`, a new parameter-free baseline-correction transformer in `chemotools.baseline`. It removes a spectrum's baseline by subtracting its lower convex hull (the "rubberband" method).

## Why is this change needed?

- `chemotools.baseline` already offers polynomial, cubic-spline, linear, constant, Whittaker-based (AirPLS/ArPLS/AsLS) and reference-subtraction baseline methods, but not the rubberband (convex-hull) method.
- Rubberband correction is a standard baseline technique in Raman and IR spectroscopy for removing broad fluorescence/scattering backgrounds. It has **no parameters to tune**, which makes it a robust default for batch processing and a useful complement to the existing tunable methods.
- This transformer was discussed directly with the maintainer (@paucablop), who encouraged opening this implementation.

## Closes

- N/A — this transformer was proposed and discussed directly with the maintainer (@paucablop), who encouraged the implementation. No separate tracking issue was opened.

## Related issues

- None

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Tests only
- [ ] CI / DevOps / tooling
- [ ] Dependency update
- [ ] Breaking change

## What changed?

- New module `chemotools/baseline/_rubberband_correction.py` implementing `RubberbandCorrection`. The baseline of each spectrum is its lower convex hull, computed with Andrew's monotone chain algorithm in feature-index space and linearly interpolated back onto every feature index, then subtracted.
- Registered `RubberbandCorrection` in `chemotools/baseline/__init__.py` (import + `__all__`).
- New test file `tests/baseline/test_rubberband_correction.py`: a scikit-learn `check_estimator` compliance test plus four functional tests.
- Documentation: added `RubberbandCorrection` to `docs/source/methods/baseline.rst` (autosummary) and `docs/source/api/baseline.rst` (import block + class table).

## What did NOT change?

- No existing transformer, public API, or behavior was modified — the change is purely additive.
- No changes to dependencies, build configuration, or CI.
- Pre-existing documentation warnings elsewhere in the project (unreferenced footnotes, toctree warnings) were left untouched, as they are out of scope for this PR.

## API and compatibility impact

- [ ] No public API changes
- [x] Public API added
- [ ] Public API changed
- [ ] Deprecation introduced
- [ ] Breaking change introduced

### Notes
- scikit-learn API compatibility: `RubberbandCorrection` is built on `BaseEstimator` + `TransformerMixin` + `OneToOneFeatureMixin` with `fit`/`transform`, following the same pattern as the other `chemotools.baseline` transformers (e.g. `LinearCorrection`). scikit-learn's `check_estimator` is exercised in the test suite.
- Affected modules/classes/functions: new public class `chemotools.baseline.RubberbandCorrection`; `chemotools.baseline.__init__` exports updated.
- Backward compatibility considerations: none — no existing names or behavior changed.

## Validation

- [x] `task format-check`
- [x] `task lint`
- [x] `task spelling`
- [x] `task type-check`
- [x] `task test`
- [ ] `task coverage`
- [ ] `task test:matrix`
- [ ] `task docs:check`
- [ ] `task build`

### Validation notes
- Ran `task check` (format-check, lint, spelling, type-check, test) locally against this branch — all five pass. Test run: 1110 passed, 10 skipped (the skips are pandas/polars optional-dependency tests, unrelated to this change).
- `task docs:check` (Sphinx build with warnings-as-errors) does not pass on this branch, but the failure is pre-existing on upstream `main`: ~20 unrelated warnings (unreferenced footnotes in the MSC/EMSC docstrings, `calibration_transfer.rst`, and several "document isn't included in any toctree" warnings). This PR's own docstring was verified to introduce **no** new docs warnings.
- `task coverage`, `task test:matrix`, and `task build` were not run locally; left to CI.

## Tests

- [x] Added new tests
- [ ] Updated existing tests
- [ ] No tests added because this PR only changes docs / CI / metadata

### Test coverage details
- Relevant test files: `tests/baseline/test_rubberband_correction.py`
- Edge cases covered: a spectrum already linear (corrected to all zeros); endpoints always lie on the hull (corrected to zero); output is non-negative everywhere; row-wise independence across a multi-spectrum batch.
- Numerical / estimator behavior checked: scikit-learn `check_estimator` compliance; a deterministic known-input/known-output case (`[0, 1, 10, 3, 4]` → `[0, 0, 8, 0, 0]`); output shape preserved.

## Documentation

- [x] Docs updated
- [x] Docstrings updated
- [ ] No docs update needed

### Documentation notes
- NumPy-style class docstring with Description, Attributes, References (Andrew 1979 + the monotone-chain reference implementation) and a runnable Examples block, matching the other baseline transformers.
- Added to the baseline autosummary (`methods/baseline.rst`) and the API reference page (`api/baseline.rst`); the in-app `?` doc-link resolves via the existing `DocLinkMixin`.

## Dependency / build / CI impact

- [x] No dependency changes
- [ ] Runtime dependency change
- [ ] Dev dependency change
- [ ] GitHub Actions / CI changed
- [ ] Build/release process changed

### Notes
- Uses only `numpy` and `scikit-learn`, both already required by chemotools.

## Reviewer focus

Please focus on:
- The convex-hull implementation in `_rubberband_baseline` — correctness of the lower-hull cross-product turn test and the interpolation back onto all feature indices.
- That the module/class layout matches chemotools conventions (file named `_rubberband_correction.py`, no `__init__`, `_parameter_constraints = {}`).

## Screenshots / logs / benchmark output

<details>
<summary>Local pytest run for the new test file</summary>

```text
$ uv run pytest tests/baseline/test_rubberband_correction.py -v
test_compliance_rubberband ................. PASSED
test_rubberband_known_correction ........... PASSED
test_rubberband_linear_spectrum_becomes_zero PASSED
test_rubberband_endpoints_and_nonnegativity  PASSED
test_rubberband_batch_is_row_wise .......... PASSED
5 passed
```

</details>

## Checklist
- [x] I linked the relevant issue(s) or explained why none exists
- [x] I kept this PR scoped to a single purpose
- [x] I added or updated tests where appropriate
- [x] I updated documentation where appropriate
- [x] I verified the change locally using the relevant tasks above
- [x] I considered backward compatibility and public API impact
- [x] I am ready for review
<img width="889" height="690" alt="Rubberband subtraction before after output" src="https://github.com/user-attachments/assets/84d5e7bb-42c4-4607-9d8a-f2a0de3ff3cf" />
