### PR TITLE
Feature implementation sst

### DIFF
--- a/chemotools/adaptation/__init__.py
+++ b/chemotools/adaptation/__init__.py
@@ -1,9 +1,11 @@
 from ._direct_standardization import DirectStandardization
 from ._piecewise_direct_standardization import PiecewiseDirectStandardization
+from ._spectral_space_transform import SpectralSpaceTransform
 from ._x_axis_interpolator import XAxisInterpolator
 
 __all__ = [
     "DirectStandardization",
     "PiecewiseDirectStandardization",
+    "SpectralSpaceTransform",
     "XAxisInterpolator",
 ]

--- a/chemotools/adaptation/_piecewise_direct_standardization.py
+++ b/chemotools/adaptation/_piecewise_direct_standardization.py
@@ -3,16 +3,17 @@ The :mod: `chemotools.adaptation._piecewise_direct_standardization`
 module implements the Piecewise Direct Standardization (PDS) transformer
 """
 
-# Author: Ruggero Guerrini
+# Author: Ruggero Guerrini & Pau Cabaneros
 # Licence: MIT
 
 import warnings
 from numbers import Integral
 
 import numpy as np
+from scipy.sparse import csr_matrix, lil_matrix
 from sklearn.base import BaseEstimator, OneToOneFeatureMixin, TransformerMixin
 from sklearn.cross_decomposition import PLSRegression
-from sklearn.utils._param_validation import Interval
+from sklearn.utils._param_validation import Interval, StrOptions
 from sklearn.utils.validation import check_is_fitted, validate_data
 
 from chemotools._doc_mixin import DocLinkMixin
@@ -29,31 +30,38 @@ class PiecewiseDirectStandardization(
 
     Parameters
     ----------
-    window_length : int
+    window_length : int, default=25
         Half-width (w) of the local spectral window used in PDS
 
-    n_components : int
+    n_components : int, default=2
         Number of components to keep for PLS model
 
     scale : bool, default = True
         Whether to scale X and Y in the PLS model
+
+    storage : str {"dense", "sparse"}, default="dense"
+        Storage format for the regression coefficients.
+        - "dense" stores the full matrix with zeros outside the local windows, while
+        - "sparse" stores only the non-zero coefficients for memory efficiency.
+
+        "sparse" is recommended for large feature sets and small window_length, while
+        "dense" may be faster for small feature sets or large window_length.
 
     Attributes
     ----------
     n_features_in_ : int
         Number of features seen during fit (set automatically by sklearn).
 
-    x_mean_ : np.ndarray of shape (n_features, 2 * window_length + 1) or None
-        Mean of the local X window for each feature. None if fitted with X_source=None
-        (identity transformation).
+    T_ : np.ndarray or scipy.sparse.csr_matrix of shape (n_features, n_features), or
+        None.
+        Banded transformation matrix mapping target instrument space to source
+        instrument space. Dense ndarray when ``storage="dense"``, CSR sparse
+        matrix when ``storage="sparse"``. None if fitted with X_source=None.
 
-    coef_ : np.ndarray of shape (n_features, 2 * window_length + 1) or None
-        Regression coefficients for each local PLS model. None if fitted with
-        X_source=None (identity transformation).
-
-    intercept_ : np.ndarray of shape (n_features,) or None
-        Intercept term for each local PLS model. None if fitted with X_source=None
-        (identity transformation).
+    bias_ : np.ndarray of shape (n_features,), or None
+        Precomputed per-feature bias that absorbs local PLS centering, allowing
+        :meth:`transform` to avoid per-sample intermediate allocations. None if
+        fitted with X_source=None.
 
     x_source_provided_ : bool
         Boolean flag indicating if X_source was provided during fitting.
@@ -63,6 +71,11 @@ class PiecewiseDirectStandardization(
     ------
     ValueError
         If X and X_source do not have the same shape.
+    ValueError
+        If ``n_components`` exceeds ``n_samples``.
+    ValueError
+        If ``n_components`` exceeds the minimum window size at the boundaries
+        (``window_length + 1``).
 
     See Also
     --------
@@ -101,13 +114,12 @@ class PiecewiseDirectStandardization(
         "window_length": [Interval(Integral, 1, None, closed="left")],
         "n_components": [Interval(Integral, 1, None, closed="left")],
         "scale": ["boolean"],
+        "storage": [StrOptions({"dense", "sparse"})],
     }
 
-    # Fitted attributes (set during fit, typed for type checkers)
     n_features_in_: int
-    x_mean_: np.ndarray | None
-    coef_: np.ndarray | None
-    intercept_: np.ndarray | None
+    T_: np.ndarray | csr_matrix | None
+    bias_: np.ndarray | None
     x_source_provided_: bool
 
     def __init__(
@@ -115,10 +127,12 @@ class PiecewiseDirectStandardization(
         window_length: int = 25,
         n_components: int = 2,
         scale: bool = True,
+        storage: str = "dense",
     ):
         self.window_length = window_length
         self.n_components = n_components
         self.scale = scale
+        self.storage = storage
 
     def fit(
         self, X: np.ndarray, y=None, *, X_source: np.ndarray | None = None
@@ -149,12 +163,6 @@ class PiecewiseDirectStandardization(
         # Check that X is a 2D array and has only finite values
         X = validate_data(self, X, ensure_2d=True, reset=True, dtype=np.float64)
 
-        # Validate n_components
-        if self.n_components > X.shape[0]:
-            raise ValueError(
-                f"n_components={self.n_components} must be <= n_samples={X.shape[0]}"
-            )
-
         # If X_source is None, default to identity transformation
         if X_source is None:
             warnings.warn(
@@ -162,10 +170,15 @@ class PiecewiseDirectStandardization(
                 "transformation."
             )
             self.x_source_provided_ = False
-            self.x_mean_ = None
-            self.coef_ = None
-            self.intercept_ = None
+            self.T_ = None
+            self.bias_ = None
             return self
+
+        # Validate n_components against n_samples
+        if self.n_components > X.shape[0]:
+            raise ValueError(
+                f"n_components={self.n_components} must be <= n_samples={X.shape[0]}"
+            )
 
         # Check that X_source is a 2D array and has only finite values
         X_source = validate_data(
@@ -179,26 +192,53 @@ class PiecewiseDirectStandardization(
                 f"got X={X.shape} and X_source={X_source.shape}."
             )
 
-        p = X.shape[1]
+        n_features = X.shape[1]
 
-        max_win = 2 * self.window_length + 1
-        self.x_mean_ = np.zeros((p, max_win), dtype=np.float64)
-        self.coef_ = np.zeros((p, max_win), dtype=np.float64)
-        self.intercept_ = np.empty(p, dtype=np.float64)
+        # Validate n_components against the minimum window size at the boundaries
+        min_win_size = self.window_length + 1
+        if self.n_components > min_win_size:
+            raise ValueError(
+                f"n_components={self.n_components} cannot be strictly greater than "
+                f"the minimum window size at the boundaries ({min_win_size}). "
+                f"Please decrease n_components or increase window_length."
+            )
 
-        for i in range(p):
+        # Pre-allocate a local build matrix (lil_matrix for sparse, ndarray for dense)
+        # and only assign to self.T_ after the final conversion, so the annotated
+        # type (ndarray | csr_matrix | None) is never violated mid-construction.
+        _T: np.ndarray | lil_matrix = (
+            lil_matrix((n_features, n_features), dtype=np.float64)
+            if self.storage == "sparse"
+            else np.zeros((n_features, n_features), dtype=np.float64)
+        )
+
+        self.bias_ = np.zeros(n_features, dtype=np.float64)
+
+        for i in range(n_features):
             l_lim = max(0, i - self.window_length)
-            r_lim = min(p, i + self.window_length + 1)
-            win_size = r_lim - l_lim
+            r_lim = min(n_features, i + self.window_length + 1)
 
+            # Fit local PLS model
             model = PLSRegression(
                 n_components=self.n_components,
                 scale=self.scale,
             ).fit(X[:, l_lim:r_lim], X_source[:, i])
 
-            self.x_mean_[i, :win_size] = X[:, l_lim:r_lim].mean(axis=0)
-            self.coef_[i, :win_size] = model.coef_.ravel()
-            self.intercept_[i] = model.intercept_[0]
+            coef = model.coef_.ravel()
+            mean = X[:, l_lim:r_lim].mean(axis=0)
+            intercept = model.intercept_[0]
+
+            # Populate the diagonal band in the build matrix
+            _T[l_lim:r_lim, i] = coef
+
+            # Precalculate the shifted bias
+            self.bias_[i] = intercept - np.dot(mean, coef)
+
+        # Convert to the appropriate format for efficient arithmetic during transform
+        if isinstance(_T, lil_matrix):
+            self.T_ = _T.tocsr()
+        else:
+            self.T_ = _T
 
         self.x_source_provided_ = True
 
@@ -206,7 +246,7 @@ class PiecewiseDirectStandardization(
 
     def transform(self, X) -> np.ndarray:
         """
-        Use the trained model to transform the source data
+        Use the trained model to transform the target data
 
         Parameters
         ----------
@@ -218,34 +258,13 @@ class PiecewiseDirectStandardization(
         X_transformed : np.ndarray of shape (n_samples, n_features)
             Data transformed
         """
-        # Verify that the model was trained
-        check_is_fitted(self)
+        check_is_fitted(self, ["x_source_provided_"])
+        X = validate_data(self, X, ensure_2d=True, reset=False, dtype=np.float64)
 
-        # Check the data
-        X = validate_data(
-            self,
-            X,
-            ensure_2d=True,
-            reset=False,
-            dtype=np.float64,
-        )
-
-        # If fitted as identity, return X unchanged
         if not self.x_source_provided_:
             return X
 
-        # Narrow types for the type checker — guaranteed non-None when
-        # x_source_provided_ is True
-        assert self.x_mean_ is not None
-        assert self.coef_ is not None
-        assert self.intercept_ is not None
+        assert self.T_ is not None
+        assert self.bias_ is not None
 
-        X_transformed = np.zeros(X.shape)
-        for i in range(self.n_features_in_):
-            l_lim = max(0, i - self.window_length)
-            r_lim = min(self.n_features_in_, i + self.window_length + 1)
-            win_size = r_lim - l_lim
-
-            X_win = X[:, l_lim:r_lim] - self.x_mean_[i, :win_size]
-            X_transformed[:, i] = X_win @ self.coef_[i, :win_size] + self.intercept_[i]
-        return X_transformed
+        return X @ self.T_ + self.bias_

--- a/chemotools/adaptation/_piecewise_direct_standardization.py
+++ b/chemotools/adaptation/_piecewise_direct_standardization.py
@@ -267,4 +267,4 @@ class PiecewiseDirectStandardization(
         assert self.T_ is not None
         assert self.bias_ is not None
 
-        return X @ self.T_ + self.bias_
+        return np.asarray(X @ self.T_ + self.bias_)

--- a/chemotools/adaptation/_piecewise_direct_standardization.py
+++ b/chemotools/adaptation/_piecewise_direct_standardization.py
@@ -1,5 +1,5 @@
 """
-The :mod: `chemotools.adaptation._piecewise_direct_standardization`
+The :mod:`chemotools.adaptation._piecewise_direct_standardization`
 module implements the Piecewise Direct Standardization (PDS) transformer
 """
 

--- a/chemotools/adaptation/_piecewise_direct_standardization.py
+++ b/chemotools/adaptation/_piecewise_direct_standardization.py
@@ -179,7 +179,6 @@ class PiecewiseDirectStandardization(
                 f"got X={X.shape} and X_source={X_source.shape}."
             )
 
-        self.x_source_provided_ = True
         p = X.shape[1]
 
         max_win = 2 * self.window_length + 1
@@ -200,6 +199,9 @@ class PiecewiseDirectStandardization(
             self.x_mean_[i, :win_size] = X[:, l_lim:r_lim].mean(axis=0)
             self.coef_[i, :win_size] = model.coef_.ravel()
             self.intercept_[i] = model.intercept_[0]
+
+        self.x_source_provided_ = True
+
         return self
 
     def transform(self, X) -> np.ndarray:
@@ -232,7 +234,7 @@ class PiecewiseDirectStandardization(
         if not self.x_source_provided_:
             return X
 
-        # Type assertions for type checker - these are guaranteed non-None when
+        # Narrow types for the type checker — guaranteed non-None when
         # x_source_provided_ is True
         assert self.x_mean_ is not None
         assert self.coef_ is not None

--- a/chemotools/adaptation/_spectral_space_transform.py
+++ b/chemotools/adaptation/_spectral_space_transform.py
@@ -152,11 +152,28 @@ class SpectralSpaceTransform(
             )
 
         x = np.hstack([X_source, X])
-        u, s, vh = np.linalg.svd(x, full_matrices=False)
-        v = vh.T
-        n_col_ref = X_source.shape[1]
 
+        # Validate that n_components does not exceed the rank of X ( [X_source, X] )
+        # after centering.
+        # Centering reduces the effective rank in the sample direction by 1, so the
+        # maximum number of meaningful components is min(n_samples - 1, 2*n_features).
+        max_components = min(x.shape[0] - 1, x.shape[1])
+        if self.n_components > max_components:
+            raise ValueError(
+                f"n_components={self.n_components} is too large. "
+                f"After mean-centering, the effective rank of X is at most "
+                f"min(n_samples - 1, 2*n_features) = {max_components}. "
+                f"Set n_components to a value <= {max_components}."
+            )
+        # Compute the SVD of the joint matrix x = [X_source | X].
+        u, s, vh = np.linalg.svd(x, full_matrices=False)
+        # Transpose vh to get V of shape (2*n_features, n_components)
+        v = vh.T
+        # n_col_ref corresponds to the number of features (for both Source and Target)
+        n_col_ref = X_source.shape[1]
+        # p1_: projection matrix for the source domain.
         self.p1_ = v[0:n_col_ref, 0 : self.n_components].T
+        # p2_: projection matrix for the target domain.
         self.p2_ = v[n_col_ref:, 0 : self.n_components].T
 
         self.x_source_provided_ = True
@@ -197,6 +214,10 @@ class SpectralSpaceTransform(
         # x_source_provided_ is True
         assert self.p1_ is not None
         assert self.p2_ is not None
-
+        # Compute the pseudo-inverse of p2_ to project from target latent space
+        # back to the feature space.
         p2_inv = np.linalg.pinv(self.p2_)
+        # Apply the transformation:
+        # X @ p2_inv @ self.p1_ : map X to the latent space, then reconstruct in source domain
+        # X - (X @ p2_inv @ self.p2_) : add back the residual not captured by the latent space
         return (X @ p2_inv @ self.p1_) + X - (X @ p2_inv @ self.p2_)

--- a/chemotools/adaptation/_spectral_space_transform.py
+++ b/chemotools/adaptation/_spectral_space_transform.py
@@ -44,7 +44,7 @@ class SpectralSpaceTransform(
     Attributes
     ----------
     n_features_in_ : int
-        Number of features seen during
+        Number of features seen during fit.
 
     p1_ : ndarray of shape (n_components, n_features), or None
         Projection matrix associated with the source domain. It maps the
@@ -53,6 +53,9 @@ class SpectralSpaceTransform(
     p2_ : ndarray of shape (n_components, n_features), or None
         Projection matrix associated with the target domain. It maps target
         data into the shared latent space.
+
+    p2_inv_ : ndarray of shape (n_components, n_features), or None
+        Pseudoinverse of p2
 
     x_source_provided_ : bool
         Boolean flag indicating if X_source was provided during fitting.
@@ -92,6 +95,7 @@ class SpectralSpaceTransform(
     n_features_in_: int
     p1_: np.ndarray | None
     p2_: np.ndarray | None
+    p2_inv_: np.ndarray | None
     x_source_provided_: bool
 
     _parameter_constraints = {
@@ -124,6 +128,7 @@ class SpectralSpaceTransform(
         self : SpectralSpaceTransform
         """
         # Validate the input parameters
+        self._validate_params()
         # Check that X is a 2D array and has only finite values
         X = validate_data(self, X, ensure_2d=True, reset=True, dtype=np.float64)
 
@@ -137,6 +142,7 @@ class SpectralSpaceTransform(
             self.n_features_in_ = X.shape[1]
             self.p1_ = None
             self.p2_ = None
+            self.p2_inv_ = None
             return self
 
         # Check that X_source is a 2D array and has only finite values
@@ -153,16 +159,16 @@ class SpectralSpaceTransform(
 
         x = np.hstack([X_source, X])
 
-        # Validate that n_components does not exceed the rank of X ( [X_source, X] )
-        # after centering.
-        # Centering reduces the effective rank in the sample direction by 1, so the
-        # maximum number of meaningful components is min(n_samples - 1, 2*n_features).
-        max_components = min(x.shape[0] - 1, x.shape[1])
+        # Validate that n_components does not exceed the rank of X ( [X_source, X] ).
+        # The SVD is applied directly to the concatenated matrix without centering,
+        # therefore the maximum rank is at most min(n_samples, 2*n_features).
+
+        max_components = min(x.shape[0], x.shape[1])
         if self.n_components > max_components:
             raise ValueError(
                 f"n_components={self.n_components} is too large. "
-                f"After mean-centering, the effective rank of X is at most "
-                f"min(n_samples - 1, 2*n_features) = {max_components}. "
+                f"The rank of the concatenated matrix is at most "
+                f"min(n_samples, 2*n_features) = {max_components}. "
                 f"Set n_components to a value <= {max_components}."
             )
         # Compute the SVD of the joint matrix x = [X_source | X].
@@ -175,7 +181,9 @@ class SpectralSpaceTransform(
         self.p1_ = v[0:n_col_ref, 0 : self.n_components].T
         # p2_: projection matrix for the target domain.
         self.p2_ = v[n_col_ref:, 0 : self.n_components].T
-
+        # Compute the pseudo-inverse of p2_ to project from target latent space
+        # back to the feature space.
+        self.p2_inv_ = np.linalg.pinv(self.p2_)
         self.x_source_provided_ = True
         self.n_features_in_ = X.shape[1]
         return self
@@ -195,7 +203,7 @@ class SpectralSpaceTransform(
             Data transformed
         """
         # Verify that the model was trained
-        check_is_fitted(self, ["p1_", "p2_"])
+        check_is_fitted(self, ["p1_", "p2_", "p2_inv_"])
 
         # Check the data
         X = validate_data(
@@ -214,12 +222,11 @@ class SpectralSpaceTransform(
         # x_source_provided_ is True
         assert self.p1_ is not None
         assert self.p2_ is not None
-        # Compute the pseudo-inverse of p2_ to project from target latent space
-        # back to the feature space.
-        p2_inv = np.linalg.pinv(self.p2_)
+        assert self.p2_inv_ is not None
+
         # Apply the transformation:
         # X @ p2_inv @ self.p1_ : map X to the latent space, then reconstruct
         # in source domain
         # X - (X @ p2_inv @ self.p2_) : add back the residual not captured by
         # the latent space
-        return (X @ p2_inv @ self.p1_) + X - (X @ p2_inv @ self.p2_)
+        return (X @ self.p2_inv_ @ self.p1_) + X - (X @ self.p2_inv_ @ self.p2_)

--- a/chemotools/adaptation/_spectral_space_transform.py
+++ b/chemotools/adaptation/_spectral_space_transform.py
@@ -79,10 +79,30 @@ class SpectralSpaceTransform(
         Projection matrix associated with the target domain. It maps target
         data into the shared latent space.
 
+    A_ : ndarray of shape (n_features, n_components), or None
+        Pseudoinverse of ``P2_``. Left factor of the low-rank correction;
+        stored to avoid recomputing the pseudoinverse on every transform call.
+
+    A_eff_ : ndarray of shape (n_features, n_components), or None
+        Effective left factor ``A_ / X_target_std_[:, None]`` with target
+        scaling absorbed. Equals ``A_`` when ``with_std=False``.
+
+    dP_eff_ : ndarray of shape (n_components, n_features), or None
+        Effective right factor ``(P1_ - P2_) * X_source_std_[None, :]`` with
+        source scaling absorbed. Equals ``P1_ - P2_`` when ``with_std=False``.
+
+    scale_ : ndarray of shape (n_features,), or None
+        Per-feature combined scale ``X_source_std_ / X_target_std_``.
+        Ones vector when ``with_std=False``.
+
+    bias_ : ndarray of shape (n_features,), or None
+        Precomputed per-feature bias that absorbs all mean and std shifts,
+        allowing :meth:`transform` to avoid intermediate array allocations.
+
     T_ : ndarray of shape (n_features, n_features), or None
-        Precomputed transformation matrix ``I + pinv(P2_) @ (P1_ - P2_)``.
-        Applying ``X_scaled @ T_`` is equivalent to the full SST formula
-        and avoids recomputing the products on every call to :meth:`transform`.
+        Full transformation matrix ``I + A_ @ (P1_ - P2_)`` (property,
+        computed on demand). Equivalent to ``X_scaled @ T_`` in the SST
+        formula but never materialised during :meth:`transform`.
 
     x_source_provided_ : bool
         Boolean flag indicating if X_source was provided during fitting.
@@ -181,7 +201,11 @@ class SpectralSpaceTransform(
             self.X_source_std_ = np.ones(X.shape[1])
             self.P1_ = None
             self.P2_ = None
-            self.T_ = None
+            self.A_ = None
+            self.A_eff_ = None
+            self.dP_eff_ = None
+            self.scale_ = None
+            self.bias_ = None
             return self
 
         # Check that X_source is a 2D array and has only finite values
@@ -259,10 +283,22 @@ class SpectralSpaceTransform(
         self.P1_ = V[0:n_col_ref, 0 : self.n_components].T
         self.P2_ = V[n_col_ref:, 0 : self.n_components].T
 
-        # Precompute the full transformation matrix T_ = I + pinv(P2_) @ (P1_ - P2_)
-        # so that transform() reduces to a single matrix multiply: X_scaled @ T_.
-        # T_ is derived from Equation 6 in [1], isolating the X_test term.
-        self.T_ = np.eye(n_col_ref) + np.linalg.pinv(self.P2_) @ (self.P1_ - self.P2_)
+        # Precompute A_ = pinv(P2_), the left factor of the low-rank correction.
+        # Storing A_ avoids recomputing the pseudoinverse on every transform call.
+        # T_ = I + A_ @ (P1_ - P2_) is available as a property (from Equation 6 in [1]).
+        self.A_ = np.linalg.pinv(self.P2_)
+
+        # Fold centering and scaling into effective factor matrices so that
+        # transform() needs only two matmuls and one vector addition.
+        dP = self.P1_ - self.P2_
+        self.A_eff_ = self.A_ / self.X_target_std_[:, None]
+        self.dP_eff_ = dP * self.X_source_std_[None, :]
+        self.scale_ = self.X_source_std_ / self.X_target_std_
+        self.bias_ = (
+            self.X_source_mean_
+            - self.X_target_mean_ * self.scale_
+            - (self.X_target_mean_ @ self.A_eff_) @ self.dP_eff_
+        )
 
         self.x_source_provided_ = True
 
@@ -298,9 +334,18 @@ class SpectralSpaceTransform(
         if not self.x_source_provided_:
             return X
 
-        # Center and scale the input using target statistics
-        X_scaled = (X - self.X_target_mean_) / self.X_target_std_
+        # Apply the precomputed factored transform (Equation 6 in [1]):
+        #   (X - mean_t)/std_t @ T_ * std_s + mean_s
+        # bias_ absorbs all mean/std shifts; A_eff_ and dP_eff_ absorb the
+        # per-feature scaling, so no intermediate arrays are needed.
+        correction = (X @ self.A_eff_) @ self.dP_eff_ + self.bias_
+        if self.with_std:
+            return X * self.scale_ + correction
+        return X + correction
 
-        # Apply the precomputed transformation matrix and unscale to source domain
-        # Equation 6 in [1], with the precomputation of T_
-        return (X_scaled @ self.T_) * self.X_source_std_ + self.X_source_mean_
+    @property
+    def T_(self) -> np.ndarray | None:
+        if not self.x_source_provided_:
+            return None
+        n = self.n_features_in_
+        return np.eye(n) + self.A_ @ (self.P1_ - self.P2_)

--- a/chemotools/adaptation/_spectral_space_transform.py
+++ b/chemotools/adaptation/_spectral_space_transform.py
@@ -26,10 +26,12 @@ class SpectralSpaceTransform(
     """
     Spectral Space Transform (SST) is a transformer used for domain adaptation
     (calibration) applications.
+
     SST is a linear transformation method used to transfer spectral data from
     a target domain to a source (reference) domain, allowing calibration
     models to remain valid across different instruments or acquisition
     conditions, following the implementation by [1]_.
+
     The method constructs a shared latent space using singular value
     decomposition (SVD) of concatenated source and target data, and derives
     projection matrices to align the target data to the source space.
@@ -40,41 +42,64 @@ class SpectralSpaceTransform(
         Number of latent components retained from the singular value
         decomposition (SVD). Controls the dimensionality of the shared subspace.
 
+    with_mean : bool, default=True
+        If True, center each domain's data by subtracting its mean before
+        computing the SVD. The source mean is added back after transforming.
+
+    with_std : bool, default=False
+        If True, scale each domain's data by its standard deviation after
+        centering. Features with zero variance are left unchanged (std set to 1).
+        Following the same convention as ``StandardScaler``.
+
 
     Attributes
     ----------
     n_features_in_ : int
         Number of features seen during fit.
 
-    p1_ : ndarray of shape (n_components, n_features), or None
+    X_target_mean_ : ndarray of shape (n_features,)
+        Per-feature mean of the target data. Zero vector when ``with_mean=False``.
+
+    X_source_mean_ : ndarray of shape (n_features,)
+        Per-feature mean of the source data. Zero vector when ``with_mean=False``.
+
+    X_target_std_ : ndarray of shape (n_features,)
+        Per-feature standard deviation of the target data.
+        Ones vector when ``with_std=False``.
+
+    X_source_std_ : ndarray of shape (n_features,)
+        Per-feature standard deviation of the source data.
+        Ones vector when ``with_std=False``.
+
+    P1_ : ndarray of shape (n_components, n_features), or None
         Projection matrix associated with the source domain. It maps the
         shared latent space back to the source spectral space.
 
-    p2_ : ndarray of shape (n_components, n_features), or None
+    P2_ : ndarray of shape (n_components, n_features), or None
         Projection matrix associated with the target domain. It maps target
         data into the shared latent space.
 
-    p2_inv_ : ndarray of shape (n_components, n_features), or None
-        Pseudoinverse of p2
+    T_ : ndarray of shape (n_features, n_features), or None
+        Precomputed transformation matrix ``I + pinv(P2_) @ (P1_ - P2_)``.
+        Applying ``X_scaled @ T_`` is equivalent to the full SST formula
+        and avoids recomputing the products on every call to :meth:`transform`.
 
     x_source_provided_ : bool
         Boolean flag indicating if X_source was provided during fitting.
-
-    References
-    ---------
-    [1] Du, W., Chen, Z.-P., Zhong, L.-J.,
-        Wang, S.-X., Yu, R.-Q., Nordon, A.,
-        Littlejohn, D., & Holden, M. (2011).
-        Maintaining the predictive abilities
-        of multivariate calibration models by
-        spectral space transformation.
-        Analytica Chimica Acta, 690(1), 64–70.
-        https://doi.org/10.1016/j.aca.2011.02.014
 
     See Also
     --------
     PiecewiseDirectStandardization : Local standardization using moving windows.
     DirectStandardization : Global linear transformation without local windows.
+
+    References
+    ---------
+    .. [1] Du, W., Chen, Z.-P., Zhong, L.-J.,Wang, S.-X., Yu, R.-Q., Nordon, A.,
+        Littlejohn, D., & Holden, M. (2011).
+        Maintaining the predictive abilities of multivariate calibration models by
+        spectral space transformation,
+        Analytica Chimica Acta, 690(1), Pages 64–70,
+        https://doi.org/10.1016/j.aca.2011.02.014.
 
     Examples
     --------
@@ -93,17 +118,30 @@ class SpectralSpaceTransform(
 
     # Fitted attributes (set during fit, typed for type checkers)
     n_features_in_: int
-    p1_: np.ndarray | None
-    p2_: np.ndarray | None
-    p2_inv_: np.ndarray | None
+    X_target_mean_: np.ndarray
+    X_source_mean_: np.ndarray
+    X_target_std_: np.ndarray
+    X_source_std_: np.ndarray
+    P1_: np.ndarray | None
+    P2_: np.ndarray | None
+    T_: np.ndarray | None
     x_source_provided_: bool
 
     _parameter_constraints = {
         "n_components": [Interval(Integral, 1, None, closed="left")],
+        "with_mean": ["boolean"],
+        "with_std": ["boolean"],
     }
 
-    def __init__(self, n_components: int = 2):
+    def __init__(
+        self,
+        n_components: int = 2,
+        with_mean: bool = True,
+        with_std: bool = False,
+    ):
         self.n_components = n_components
+        self.with_mean = with_mean
+        self.with_std = with_std
 
     def fit(
         self, X: np.ndarray, y=None, *, X_source: np.ndarray | None = None
@@ -129,6 +167,7 @@ class SpectralSpaceTransform(
         """
         # Validate the input parameters
         self._validate_params()
+
         # Check that X is a 2D array and has only finite values
         X = validate_data(self, X, ensure_2d=True, reset=True, dtype=np.float64)
 
@@ -140,9 +179,13 @@ class SpectralSpaceTransform(
             )
             self.x_source_provided_ = False
             self.n_features_in_ = X.shape[1]
-            self.p1_ = None
-            self.p2_ = None
-            self.p2_inv_ = None
+            self.X_target_mean_ = np.zeros(X.shape[1])
+            self.X_source_mean_ = np.zeros(X.shape[1])
+            self.X_target_std_ = np.ones(X.shape[1])
+            self.X_source_std_ = np.ones(X.shape[1])
+            self.P1_ = None
+            self.P2_ = None
+            self.T_ = None
             return self
 
         # Check that X_source is a 2D array and has only finite values
@@ -157,13 +200,46 @@ class SpectralSpaceTransform(
                 f"got X={X.shape} and X_source={X_source.shape}."
             )
 
-        x = np.hstack([X_source, X])
+        # Compute centering/scaling statistics for source and target domains
+        self.X_target_mean_ = (
+            np.mean(X, axis=0) if self.with_mean else np.zeros(X.shape[1])
+        )
+        self.X_source_mean_ = (
+            np.mean(X_source, axis=0) if self.with_mean else np.zeros(X_source.shape[1])
+        )
+        if self.with_std:
+            self.X_target_std_ = np.std(X, axis=0, ddof=0)
+            self.X_source_std_ = np.std(X_source, axis=0, ddof=0)
+            # Handle zero-variance features to avoid division by zero
+            target_zero = self.X_target_std_ == 0
+            source_zero = self.X_source_std_ == 0
+            if target_zero.any():
+                warnings.warn(
+                    f"X (target) has {target_zero.sum()} constant feature(s). "
+                    "Their standard deviation is set to 1 to avoid division by zero."
+                )
+            if source_zero.any():
+                warnings.warn(
+                    f"X_source has {source_zero.sum()} constant feature(s). "
+                    "Their standard deviation is set to 1 to avoid division by zero."
+                )
+            self.X_target_std_[target_zero] = 1.0
+            self.X_source_std_[source_zero] = 1.0
+        else:
+            self.X_target_std_ = np.ones(X.shape[1])
+            self.X_source_std_ = np.ones(X.shape[1])
 
-        # Validate that n_components does not exceed the rank of X ( [X_source, X] ).
-        # The SVD is applied directly to the concatenated matrix without centering,
-        # therefore the maximum rank is at most min(n_samples, 2*n_features).
+        # Center and scale source and target data
+        X_scaled = (X - self.X_target_mean_) / self.X_target_std_
+        X_source_scaled = (X_source - self.X_source_mean_) / self.X_source_std_
 
-        max_components = min(x.shape[0], x.shape[1])
+        # Create X_comb from centered/scaled source and target data (Section 2 in [1])
+        X_comb = np.hstack([X_source_scaled, X_scaled])
+
+        # Validate that n_components does not exceed the rank of X_comb ([X_source, X]).
+        # The maximum rank is at most min(n_samples, 2*n_features).
+
+        max_components = min(X_comb.shape[0], X_comb.shape[1])
         if self.n_components > max_components:
             raise ValueError(
                 f"n_components={self.n_components} is too large. "
@@ -171,21 +247,29 @@ class SpectralSpaceTransform(
                 f"min(n_samples, 2*n_features) = {max_components}. "
                 f"Set n_components to a value <= {max_components}."
             )
-        # Compute the SVD of the joint matrix x = [X_source | X].
-        u, s, vh = np.linalg.svd(x, full_matrices=False)
-        # Transpose vh to get V of shape (2*n_features, n_components)
-        v = vh.T
+
+        # Compute the SVD of the joint matrix X_comb = [X_source | X]
+        # Equation 1 in [1].
+        _, _, Vt = np.linalg.svd(X_comb, full_matrices=False)
+
+        # Transpose Vt to get V of shape (2*n_features, n_components)
+        V = Vt.T
+
         # n_col_ref corresponds to the number of features (for both Source and Target)
         n_col_ref = X_source.shape[1]
-        # p1_: projection matrix for the source domain.
-        self.p1_ = v[0:n_col_ref, 0 : self.n_components].T
-        # p2_: projection matrix for the target domain.
-        self.p2_ = v[n_col_ref:, 0 : self.n_components].T
-        # Compute the pseudo-inverse of p2_ to project from target latent space
-        # back to the feature space.
-        self.p2_inv_ = np.linalg.pinv(self.p2_)
+
+        # Define projection matrices for the source and target domains.
+        # Equation 1 in [1].
+        self.P1_ = V[0:n_col_ref, 0 : self.n_components].T
+        self.P2_ = V[n_col_ref:, 0 : self.n_components].T
+
+        # Precompute the full transformation matrix T_ = I + pinv(P2_) @ (P1_ - P2_)
+        # so that transform() reduces to a single matrix multiply: X_scaled @ T_.
+        # T_ is derived from Equation 6 in [1], isolating the X_test term.
+        self.T_ = np.eye(n_col_ref) + np.linalg.pinv(self.P2_) @ (self.P1_ - self.P2_)
+
         self.x_source_provided_ = True
-        self.n_features_in_ = X.shape[1]
+
         return self
 
     def transform(self, X: np.ndarray) -> np.ndarray:
@@ -203,7 +287,7 @@ class SpectralSpaceTransform(
             Data transformed
         """
         # Verify that the model was trained
-        check_is_fitted(self, ["p1_", "p2_", "p2_inv_"])
+        check_is_fitted(self, ["x_source_provided_"])
 
         # Check the data
         X = validate_data(
@@ -218,15 +302,9 @@ class SpectralSpaceTransform(
         if not self.x_source_provided_:
             return X
 
-        # Type assertions for type checker - these are guaranteed non-None when
-        # x_source_provided_ is True
-        assert self.p1_ is not None
-        assert self.p2_ is not None
-        assert self.p2_inv_ is not None
+        # Center and scale the input using target statistics
+        X_scaled = (X - self.X_target_mean_) / self.X_target_std_
 
-        # Apply the transformation:
-        # X @ p2_inv @ self.p1_ : map X to the latent space, then reconstruct
-        # in source domain
-        # X - (X @ p2_inv @ self.p2_) : add back the residual not captured by
-        # the latent space
-        return (X @ self.p2_inv_ @ self.p1_) + X - (X @ self.p2_inv_ @ self.p2_)
+        # Apply the precomputed transformation matrix and unscale to source domain
+        # Equation 6 in [1], with the precomputation of T_
+        return (X_scaled @ self.T_) * self.X_source_std_ + self.X_source_mean_

--- a/chemotools/adaptation/_spectral_space_transform.py
+++ b/chemotools/adaptation/_spectral_space_transform.py
@@ -150,6 +150,11 @@ class SpectralSpaceTransform(
         "with_std": ["boolean"],
     }
 
+    n_features_in_: int
+    P1_: np.ndarray | None
+    P2_: np.ndarray | None
+    A_: np.ndarray | None
+
     def __init__(
         self,
         n_components: int = 2,
@@ -347,5 +352,8 @@ class SpectralSpaceTransform(
     def T_(self) -> np.ndarray | None:
         if not self.x_source_provided_:
             return None
+        assert self.A_ is not None
+        assert self.P1_ is not None
+        assert self.P2_ is not None
         n = self.n_features_in_
         return np.eye(n) + self.A_ @ (self.P1_ - self.P2_)

--- a/chemotools/adaptation/_spectral_space_transform.py
+++ b/chemotools/adaptation/_spectral_space_transform.py
@@ -1,0 +1,202 @@
+"""
+The :mod: `chemotools.adaptation._spectral_space_transform`
+module implements the Spectral Space Transform (SST) transformer
+"""
+
+# Authors: Ruggero Guerrini
+# License: MIT
+
+import warnings
+from numbers import Integral
+
+import numpy as np
+from sklearn.base import BaseEstimator, OneToOneFeatureMixin, TransformerMixin
+from sklearn.utils._param_validation import Interval
+from sklearn.utils.validation import (
+    check_is_fitted,
+    validate_data,
+)
+
+from chemotools._doc_mixin import DocLinkMixin
+
+
+class SpectralSpaceTransform(
+    DocLinkMixin, OneToOneFeatureMixin, TransformerMixin, BaseEstimator
+):
+    """
+    Spectral Space Transform (SST) is a transformer used for domain adaptation
+    (calibration) applications.
+    SST is a linear transformation method used to transfer spectral data from
+    a target domain to a source (reference) domain, allowing calibration
+    models to remain valid across different instruments or acquisition
+    conditions, following the implementation by [1]_.
+    The method constructs a shared latent space using singular value
+    decomposition (SVD) of concatenated source and target data, and derives
+    projection matrices to align the target data to the source space.
+
+    Parameters
+    ----------
+    n_components : int, default=2
+        Number of latent components retained from the singular value
+        decomposition (SVD). Controls the dimensionality of the shared subspace.
+
+
+    Attributes
+    ----------
+    n_features_in_ : int
+        Number of features seen during
+
+    p1_ : ndarray of shape (n_components, n_features), or None
+        Projection matrix associated with the source domain. It maps the
+        shared latent space back to the source spectral space.
+
+    p2_ : ndarray of shape (n_components, n_features), or None
+        Projection matrix associated with the target domain. It maps target
+        data into the shared latent space.
+
+    x_source_provided_ : bool
+        Boolean flag indicating if X_source was provided during fitting.
+
+    References
+    ---------
+    [1] Du, W., Chen, Z.-P., Zhong, L.-J.,
+        Wang, S.-X., Yu, R.-Q., Nordon, A.,
+        Littlejohn, D., & Holden, M. (2011).
+        Maintaining the predictive abilities
+        of multivariate calibration models by
+        spectral space transformation.
+        Analytica Chimica Acta, 690(1), 64–70.
+        https://doi.org/10.1016/j.aca.2011.02.014
+
+    See Also
+    --------
+    PiecewiseDirectStandardization : Local standardization using moving windows.
+    DirectStandardization : Global linear transformation without local windows.
+
+    Examples
+    --------
+    **Basic usage**
+    >>> import numpy as np
+    >>> from chemotools.adaptation import SpectralSpaceTransform
+    >>>
+    >>> rng = np.random.default_rng(17)
+    >>> X_source = rng.normal(size=(100, 20))
+    >>> X_target = X_source * 2 - rng.normal(size=(100, 20)) * 0.02
+    >>>
+    >>> sst = SpectralSpaceTransform(n_components=2).fit(X_target, X_source=X_source)
+    >>> X_transf = sst.transform(X_target)
+
+    """
+
+    # Fitted attributes (set during fit, typed for type checkers)
+    n_features_in_: int
+    p1_: np.ndarray | None
+    p2_: np.ndarray | None
+    x_source_provided_: bool
+
+    _parameter_constraints = {
+        "n_components": [Interval(Integral, 1, None, closed="left")],
+    }
+
+    def __init__(self, n_components: int = 2):
+        self.n_components = n_components
+
+    def fit(
+        self, X: np.ndarray, y=None, *, X_source: np.ndarray | None = None
+    ) -> "SpectralSpaceTransform":
+        """
+        Fit the SpectralSpaceTransform model.
+
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_samples, n_features)
+            Data from the target instrument.
+
+        y : None
+            Ignored to align with API.
+
+        X_source : np.ndarray of shape (n_samples, n_features), optional
+            Data from the source instrument. If None, the transformer defaults to
+            an identity transformation.
+
+        Returns
+        -------
+        self : SpectralSpaceTransform
+        """
+        # Validate the input parameters
+        # Check that X is a 2D array and has only finite values
+        X = validate_data(self, X, ensure_2d=True, reset=True, dtype=np.float64)
+
+        # If X_source is None, default to identity transformation
+        if X_source is None:
+            warnings.warn(
+                "X_source is None, the transformer will act as an identity "
+                "transformation."
+            )
+            self.x_source_provided_ = False
+            self.n_features_in_ = X.shape[1]
+            self.p1_ = None
+            self.p2_ = None
+            return self
+
+        # Check that X_source is a 2D array and has only finite values
+        X_source = validate_data(
+            self, X_source, ensure_2d=True, reset=False, dtype=np.float64
+        )
+
+        # Check consistency between X and X_source
+        if X_source.shape != X.shape:
+            raise ValueError(
+                f"X and X_source must have the same shape, "
+                f"got X={X.shape} and X_source={X_source.shape}."
+            )
+
+        x = np.hstack([X_source, X])
+        u, s, vh = np.linalg.svd(x, full_matrices=False)
+        v = vh.T
+        n_col_ref = X_source.shape[1]
+
+        self.p1_ = v[0:n_col_ref, 0 : self.n_components].T
+        self.p2_ = v[n_col_ref:, 0 : self.n_components].T
+
+        self.x_source_provided_ = True
+        self.n_features_in_ = X.shape[1]
+        return self
+
+    def transform(self, X: np.ndarray) -> np.ndarray:
+        """
+        Use the trained model to transform the target data
+
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_samples, n_features)
+            Input data to transform
+
+        Returns
+        -------
+        X_transformed : np.ndarray of shape (n_samples, n_features)
+            Data transformed
+        """
+        # Verify that the model was trained
+        check_is_fitted(self, ["p1_", "p2_"])
+
+        # Check the data
+        X = validate_data(
+            self,
+            X,
+            ensure_2d=True,
+            reset=False,
+            dtype=np.float64,
+        )
+
+        # If fitted as identity, return X unchanged
+        if not self.x_source_provided_:
+            return X
+
+        # Type assertions for type checker - these are guaranteed non-None when
+        # x_source_provided_ is True
+        assert self.p1_ is not None
+        assert self.p2_ is not None
+
+        p2_inv = np.linalg.pinv(self.p2_)
+        return (X @ p2_inv @ self.p1_) + X - (X @ p2_inv @ self.p2_)

--- a/chemotools/adaptation/_spectral_space_transform.py
+++ b/chemotools/adaptation/_spectral_space_transform.py
@@ -1,5 +1,5 @@
 """
-The :mod: `chemotools.adaptation._spectral_space_transform`
+The :mod:`chemotools.adaptation._spectral_space_transform`
 module implements the Spectral Space Transform (SST) transformer
 """
 

--- a/chemotools/adaptation/_spectral_space_transform.py
+++ b/chemotools/adaptation/_spectral_space_transform.py
@@ -218,6 +218,8 @@ class SpectralSpaceTransform(
         # back to the feature space.
         p2_inv = np.linalg.pinv(self.p2_)
         # Apply the transformation:
-        # X @ p2_inv @ self.p1_ : map X to the latent space, then reconstruct in source domain
-        # X - (X @ p2_inv @ self.p2_) : add back the residual not captured by the latent space
+        # X @ p2_inv @ self.p1_ : map X to the latent space, then reconstruct
+        # in source domain
+        # X - (X @ p2_inv @ self.p2_) : add back the residual not captured by
+        # the latent space
         return (X @ p2_inv @ self.p1_) + X - (X @ p2_inv @ self.p2_)

--- a/chemotools/adaptation/_spectral_space_transform.py
+++ b/chemotools/adaptation/_spectral_space_transform.py
@@ -87,6 +87,14 @@ class SpectralSpaceTransform(
     x_source_provided_ : bool
         Boolean flag indicating if X_source was provided during fitting.
 
+    Raises
+    ------
+    ValueError
+        If ``X`` and ``X_source`` do not have the same shape.
+    ValueError
+        If ``n_components`` exceeds ``min(n_samples, 2 * n_features)`` of the
+        concatenated matrix.
+
     See Also
     --------
     PiecewiseDirectStandardization : Local standardization using moving windows.
@@ -116,6 +124,12 @@ class SpectralSpaceTransform(
 
     """
 
+    _parameter_constraints = {
+        "n_components": [Interval(Integral, 1, None, closed="left")],
+        "with_mean": ["boolean"],
+        "with_std": ["boolean"],
+    }
+
     # Fitted attributes (set during fit, typed for type checkers)
     n_features_in_: int
     X_target_mean_: np.ndarray
@@ -126,12 +140,6 @@ class SpectralSpaceTransform(
     P2_: np.ndarray | None
     T_: np.ndarray | None
     x_source_provided_: bool
-
-    _parameter_constraints = {
-        "n_components": [Interval(Integral, 1, None, closed="left")],
-        "with_mean": ["boolean"],
-        "with_std": ["boolean"],
-    }
 
     def __init__(
         self,

--- a/chemotools/adaptation/_spectral_space_transform.py
+++ b/chemotools/adaptation/_spectral_space_transform.py
@@ -101,7 +101,7 @@ class SpectralSpaceTransform(
     DirectStandardization : Global linear transformation without local windows.
 
     References
-    ---------
+    ----------
     .. [1] Du, W., Chen, Z.-P., Zhong, L.-J.,Wang, S.-X., Yu, R.-Q., Nordon, A.,
         Littlejohn, D., & Holden, M. (2011).
         Maintaining the predictive abilities of multivariate calibration models by
@@ -129,17 +129,6 @@ class SpectralSpaceTransform(
         "with_mean": ["boolean"],
         "with_std": ["boolean"],
     }
-
-    # Fitted attributes (set during fit, typed for type checkers)
-    n_features_in_: int
-    X_target_mean_: np.ndarray
-    X_source_mean_: np.ndarray
-    X_target_std_: np.ndarray
-    X_source_std_: np.ndarray
-    P1_: np.ndarray | None
-    P2_: np.ndarray | None
-    T_: np.ndarray | None
-    x_source_provided_: bool
 
     def __init__(
         self,
@@ -186,7 +175,6 @@ class SpectralSpaceTransform(
                 "transformation."
             )
             self.x_source_provided_ = False
-            self.n_features_in_ = X.shape[1]
             self.X_target_mean_ = np.zeros(X.shape[1])
             self.X_source_mean_ = np.zeros(X.shape[1])
             self.X_target_std_ = np.ones(X.shape[1])

--- a/chemotools/adaptation/_x_axis_interpolator.py
+++ b/chemotools/adaptation/_x_axis_interpolator.py
@@ -66,6 +66,9 @@ class XAxisInterpolator(DocLinkMixin, TransformerMixin, BaseEstimator):
         "right": [Interval(Real, None, None, closed="neither"), None, np.nan.__class__],
     }
 
+    n_features_in_: int
+    common_x_axis_: np.ndarray
+
     def __init__(
         self,
         common_x_axis: np.ndarray,
@@ -99,11 +102,8 @@ class XAxisInterpolator(DocLinkMixin, TransformerMixin, BaseEstimator):
         -------
         self : object
         """
-        # Validate the input parameters
-        self._validate_params()
-
         # Validate the X data
-        validate_data(self, X, ensure_2d=True, dtype="numeric")
+        validate_data(self, X, ensure_2d=True, reset=True, dtype="numeric")
 
         # Validate the common_x_axis
         common_x_axis = np.asarray(self.common_x_axis, dtype=float)

--- a/docs/locale/es/LC_MESSAGES/methods/adaptation_methods.po
+++ b/docs/locale/es/LC_MESSAGES/methods/adaptation_methods.po
@@ -57,6 +57,22 @@ msgstr ""
 
 #: ../../source/methods/adaptation_methods.rst:9:<autosummary>:1
 msgid ""
+":py:obj:`SpectralSpaceTransform "
+"<chemotools.adaptation.SpectralSpaceTransform>`"
+msgstr ""
+":py:obj:`SpectralSpaceTransform "
+"<chemotools.adaptation.SpectralSpaceTransform>`"
+
+#: ../../source/methods/adaptation_methods.rst:9:<autosummary>:1
+msgid ""
+"Spectral Space Transform (SST) is a transformer used for domain adaptation "
+"(calibration) applications."
+msgstr ""
+"La Transformada del Espacio Espectral (SST) es un transformador utilizado "
+"para aplicaciones de adaptación de dominio (calibración)."
+
+#: ../../source/methods/adaptation_methods.rst:9:<autosummary>:1
+msgid ""
 ":py:obj:`XAxisInterpolator "
 "<chemotools.adaptation.XAxisInterpolator>`"
 msgstr ""

--- a/docs/locale/ja/LC_MESSAGES/methods/adaptation_methods.po
+++ b/docs/locale/ja/LC_MESSAGES/methods/adaptation_methods.po
@@ -57,6 +57,22 @@ msgstr ""
 
 #: ../../source/methods/adaptation_methods.rst:9:<autosummary>:1
 msgid ""
+":py:obj:`SpectralSpaceTransform "
+"<chemotools.adaptation.SpectralSpaceTransform>`"
+msgstr ""
+":py:obj:`SpectralSpaceTransform "
+"<chemotools.adaptation.SpectralSpaceTransform>`"
+
+#: ../../source/methods/adaptation_methods.rst:9:<autosummary>:1
+msgid ""
+"Spectral Space Transform (SST) is a transformer used for domain adaptation "
+"(calibration) applications."
+msgstr ""
+"スペクトル空間変換（SST）は、ドメイン適応（キャリブレーション）アプリケーションに"
+"使用されるトランスフォーマーです。"
+
+#: ../../source/methods/adaptation_methods.rst:9:<autosummary>:1
+msgid ""
 ":py:obj:`XAxisInterpolator "
 "<chemotools.adaptation.XAxisInterpolator>`"
 msgstr ""

--- a/docs/locale/zh_CN/LC_MESSAGES/methods/adaptation_methods.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/methods/adaptation_methods.po
@@ -55,6 +55,21 @@ msgstr ""
 
 #: ../../source/methods/adaptation_methods.rst:9:<autosummary>:1
 msgid ""
+":py:obj:`SpectralSpaceTransform "
+"<chemotools.adaptation.SpectralSpaceTransform>`"
+msgstr ""
+":py:obj:`SpectralSpaceTransform "
+"<chemotools.adaptation.SpectralSpaceTransform>`"
+
+#: ../../source/methods/adaptation_methods.rst:9:<autosummary>:1
+msgid ""
+"Spectral Space Transform (SST) is a transformer used for domain adaptation "
+"(calibration) applications."
+msgstr ""
+"光谱空间变换（SST）是一种用于域适应（校准）应用的转换器。"
+
+#: ../../source/methods/adaptation_methods.rst:9:<autosummary>:1
+msgid ""
 ":py:obj:`XAxisInterpolator "
 "<chemotools.adaptation.XAxisInterpolator>`"
 msgstr ""

--- a/docs/source/api/adaptation.rst
+++ b/docs/source/api/adaptation.rst
@@ -12,6 +12,7 @@ Adaptation methods for calibration transfer between instruments. These transform
    from chemotools.adaptation import (
        DirectStandardization,
        PiecewiseDirectStandardization,
+       SpectralSpaceTransform,
        XAxisInterpolator,
    )
 
@@ -28,6 +29,8 @@ Available Classes
      - Linear calibration transfer via least-squares mapping between instruments
    * - :doc:`PiecewiseDirectStandardization </methods/generated/chemotools.adaptation.PiecewiseDirectStandardization>`
      - Piecewise calibration transfer using local least-squares windows
+   * - :doc:`SpectralSpaceTransform </methods/generated/chemotools.adaptation.SpectralSpaceTransform>`
+     - SVD-based shared latent space domain adaptation
    * - :doc:`XAxisInterpolator </methods/generated/chemotools.adaptation.XAxisInterpolator>`
      - Resample spectra onto a shared x-axis grid via interpolation
 

--- a/docs/source/methods/adaptation_methods.rst
+++ b/docs/source/methods/adaptation_methods.rst
@@ -9,4 +9,5 @@ Adaptation Methods
 
     DirectStandardization
     PiecewiseDirectStandardization
+    SpectralSpaceTransform
     XAxisInterpolator

--- a/tests/adaptation/conftest.py
+++ b/tests/adaptation/conftest.py
@@ -4,32 +4,102 @@ import numpy as np
 import pytest
 
 
+def _make_spectral_data(
+    rng: np.random.Generator,
+    n_samples: int,
+    n_features: int = 50,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Generate paired (source, target) spectral data using a Beer-Lambert model.
+
+    Spectra are formed as a linear mixture of Gaussian peaks, giving correlated
+    features with a positive (non-zero) mean — like real absorbance data.  The
+    target instrument adds a smooth multiplicative gain and additive offset so
+    that centering bugs and window-structure issues are detectable, unlike the
+    mean-zero i.i.d. data that would mask them.
+
+    Parameters
+    ----------
+    rng : np.random.Generator
+    n_samples : int
+    n_features : int, default=50
+
+    Returns
+    -------
+    X_source : ndarray of shape (n_samples, n_features)
+    X_target : ndarray of shape (n_samples, n_features)
+    C : ndarray of shape (n_samples, 4) — concentration matrix
+    """
+    n_components = 4
+    wavenumbers = np.linspace(0, 1, n_features)
+
+    # Smooth Gaussian spectral basis — correlated features, positive mean
+    peaks = [0.15, 0.40, 0.65, 0.85]
+    widths = [0.07, 0.08, 0.06, 0.07]
+    basis = np.stack(
+        [np.exp(-0.5 * ((wavenumbers - p) / w) ** 2) for p, w in zip(peaks, widths)]
+    )  # (n_components, n_features)
+
+    # Positive concentrations → spectra have positive mean (Beer-Lambert law)
+    C = rng.uniform(0.05, 1.0, size=(n_samples, n_components))
+    X_ref = C @ basis  # (n_samples, n_features)
+
+    # Smooth instrument effects: multiplicative gain + additive baseline + noise
+    gain = 1.0 + 0.08 * np.sin(np.linspace(0, np.pi, n_features))
+    offset = 0.04 * (1.0 + np.cos(np.linspace(0, 2 * np.pi, n_features)))
+    noise_std = 0.003
+
+    X_source = X_ref + rng.normal(0, noise_std, size=X_ref.shape)
+    X_target = X_ref * gain + offset + rng.normal(0, noise_std, size=X_ref.shape)
+
+    return X_source, X_target, C
+
+
 @pytest.fixture
 def sample_data():
-    """Generate sample data for adaptation tests.
+    """Paired spectral fixture shared by all adaptation transformer tests.
 
-    Returns:
-        tuple: (X_target, X_source) where:
-            - X_source is the source/reference instrument data (base)
-            - X_target is the target instrument data to be calibrated (scaled version)
+    Returns Beer-Lambert spectra (positive mean, smooth feature correlation)
+    with a realistic instrument transfer: smooth multiplicative gain plus
+    additive baseline offset plus noise.  The non-zero mean and correlated
+    features make centering bugs and window-structure issues detectable, unlike
+    mean-zero i.i.d. data.
+
+    Returns
+    -------
+    tuple : (X_target, X_source)
+        X_target : ndarray of shape (100, 50) — target instrument spectra
+        X_source : ndarray of shape (100, 50) — source (reference) spectra
     """
     rng = np.random.default_rng(17)
-    X_source = rng.normal(size=(100, 20))
-    X_target = X_source * 2 - rng.normal(size=(100, 20)) * 0.02
+    X_source, X_target, _ = _make_spectral_data(rng, n_samples=100)
     return X_target, X_source
 
 
-def data_diff(dataset_ref, dataset_test):
-    """Calculate normalized difference between two datasets.
+@pytest.fixture
+def labeled_sample_data():
+    """Paired spectral fixture with concentration labels for end-to-end tests.
 
-    Args:
-        dataset_ref: Reference dataset
-        dataset_test: Test dataset
+    Use this fixture to verify that a calibration transfer improves downstream
+    prediction accuracy, not just spectral distance.  ``y`` is the concentration
+    of the first spectral component, which has a known linear relationship to
+    the spectra.
 
-    Returns:
-        float: Normalized difference (||ref - test|| / ||ref||)
+    Returns
+    -------
+    tuple : (X_target_train, X_source_train, y_train, X_target_test, y_test)
+        All arrays have n_features=50.  Train split: 80 samples; test: 20 samples.
     """
-    diff_norm = np.linalg.norm(dataset_ref - dataset_test)
-    ref_norm = np.linalg.norm(dataset_ref)
-    difference = diff_norm / ref_norm
-    return difference
+    rng = np.random.default_rng(42)
+    X_source, X_target, C = _make_spectral_data(rng, n_samples=100)
+    y = C[:, 0]
+    return X_target[:80], X_source[:80], y[:80], X_target[80:], y[80:]
+
+
+def data_diff(dataset_ref, dataset_test) -> float:
+    """Normalized Frobenius distance: ||ref - test|| / ||ref||."""
+    return np.linalg.norm(dataset_ref - dataset_test) / np.linalg.norm(dataset_ref)
+
+
+def rmse(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    """Root mean squared error."""
+    return float(np.sqrt(np.mean((y_true - y_pred.ravel()) ** 2)))

--- a/tests/adaptation/test_direct_standardization.py
+++ b/tests/adaptation/test_direct_standardization.py
@@ -59,8 +59,8 @@ class TestFit:
         with pytest.raises(
             ValueError,
             match=re.escape(
-                "X and X_source must have the same shape, got X=(100, 20) and "
-                "X_source=(99, 20)."
+                "X and X_source must have the same shape, got X=(100, 50) and "
+                "X_source=(99, 50)."
             ),
         ):
             DirectStandardization().fit(X_target, X_source=X_source[:-1, :])
@@ -171,7 +171,7 @@ class TestTransform:
         # Arrange
         X_target, X_source = sample_data
         rng = np.random.default_rng(99)
-        X_wrong = rng.normal(size=(100, 15))  # 15 instead of 20
+        X_wrong = rng.normal(size=(100, 15))  # 15 instead of 50
         model = DirectStandardization().fit(X_source)
 
         # Act & Assert

--- a/tests/adaptation/test_piecewise_direct_standardization.py
+++ b/tests/adaptation/test_piecewise_direct_standardization.py
@@ -73,8 +73,8 @@ class TestFit:
         with pytest.raises(
             ValueError,
             match=re.escape(
-                "X and X_source must have the same shape, got X=(100, 20) and "
-                "X_source=(99, 20)."
+                "X and X_source must have the same shape, got X=(100, 50) and "
+                "X_source=(99, 50)."
             ),
         ):
             model.fit(X_target, X_source=X_source[:-1, :])
@@ -390,7 +390,7 @@ class TestPipeline:
 
             # Act
             grid.fit(X_target, y_concentration, X_source=X_source)
-            X_test = rng.normal(size=(10, 20))
+            X_test = rng.normal(size=(10, 50))
             y_pred = grid.best_estimator_.predict(X_test)
 
             # Assert

--- a/tests/adaptation/test_piecewise_direct_standardization.py
+++ b/tests/adaptation/test_piecewise_direct_standardization.py
@@ -49,19 +49,17 @@ class TestFit:
 
         # Assert - Check attributes exist with correct shapes
         assert hasattr(model, "n_features_in_")
-        assert hasattr(model, "x_mean_")
-        assert hasattr(model, "coef_")
-        assert hasattr(model, "intercept_")
-        assert model.x_mean_.shape == (X_target.shape[1], 2 * model.window_length + 1)
-        assert model.coef_.shape == (X_target.shape[1], 2 * model.window_length + 1)
-        assert model.intercept_.shape == (X_target.shape[1],)
+        assert hasattr(model, "T_")
+        assert hasattr(model, "bias_")
+        assert model.T_.shape == (X_target.shape[1], X_target.shape[1])
+        assert model.bias_.shape == (X_target.shape[1],)
         assert model.n_features_in_ == X_target.shape[1]
 
         # Assert - Check values are finite and reasonable
-        assert np.all(np.isfinite(model.x_mean_))
-        assert np.all(np.isfinite(model.coef_))
-        assert np.all(np.isfinite(model.intercept_))
-        assert np.all(np.abs(model.coef_) < 100)  # Reasonable magnitude
+        T_dense = model.T_.toarray() if hasattr(model.T_, "toarray") else model.T_
+        assert np.all(np.isfinite(T_dense))
+        assert np.all(np.isfinite(model.bias_))
+        assert np.abs(T_dense).max() < 100  # Reasonable magnitude
 
     def test_fit_raises_on_shape_mismatch(self, sample_data):
         """Verifies fit raises ValueError when X and X_source have different shapes."""
@@ -269,8 +267,10 @@ class TestNumericalCorrectness:
 
         # Assert - Results should be bit-for-bit identical
         np.testing.assert_array_equal(result1, result2)
-        np.testing.assert_array_equal(model1.coef_, model2.coef_)
-        np.testing.assert_array_equal(model1.intercept_, model2.intercept_)
+        np.testing.assert_array_equal(model1.bias_, model2.bias_)
+        T1 = model1.T_.toarray() if hasattr(model1.T_, "toarray") else model1.T_
+        T2 = model2.T_.toarray() if hasattr(model2.T_, "toarray") else model2.T_
+        np.testing.assert_array_equal(T1, T2)
 
     def test_known_linear_transformation(self):
         """Verifies correct behavior on a known linear transformation."""
@@ -332,9 +332,9 @@ class TestEdgeCases:
 
         # Assert - transformation should still work correctly
         assert X_transformed.shape == X.shape
-        # For edge features with window_length >> n_features, all features are used
-        assert model.x_mean_.shape == (10, 101)  # 2 * 50 + 1
-        assert model.coef_.shape == (10, 101)
+        # T_ is square with shape (n_features, n_features) regardless of window_length
+        assert model.T_.shape == (10, 10)
+        assert model.bias_.shape == (10,)
 
     def test_window_length_equals_one(self):
         """Verifies that minimal window_length of 1 works correctly."""
@@ -350,9 +350,9 @@ class TestEdgeCases:
 
         # Assert
         assert X_transformed.shape == X.shape
-        # Interior features use 3 features, edges use fewer
-        assert model.x_mean_.shape == (20, 3)  # 2 * 1 + 1
-        assert model.coef_.shape == (20, 3)
+        # T_ is always square (n_features, n_features)
+        assert model.T_.shape == (20, 20)
+        assert model.bias_.shape == (20,)
 
 
 class TestPipeline:

--- a/tests/adaptation/test_piecewise_direct_standardization.py
+++ b/tests/adaptation/test_piecewise_direct_standardization.py
@@ -10,6 +10,7 @@ import re
 import numpy as np
 import pytest
 import sklearn
+from scipy.sparse import csr_matrix
 from sklearn.cross_decomposition import PLSRegression
 from sklearn.exceptions import NotFittedError
 from sklearn.model_selection import GridSearchCV
@@ -59,7 +60,7 @@ class TestFit:
         T_dense = model.T_.toarray() if hasattr(model.T_, "toarray") else model.T_
         assert np.all(np.isfinite(T_dense))
         assert np.all(np.isfinite(model.bias_))
-        assert np.abs(T_dense).max() < 100  # Reasonable magnitude
+        assert np.abs(T_dense).max() < 100
 
     def test_fit_raises_on_shape_mismatch(self, sample_data):
         """Verifies fit raises ValueError when X and X_source have different shapes."""
@@ -101,6 +102,18 @@ class TestFit:
             match=re.escape("n_components=15 must be <= n_samples=10"),
         ):
             model.fit(X, X_source=X_source)
+
+    def test_fit_stores_T_as_sparse(self, sample_data):
+        """Verifies fit stores T_ as a sparse matrix when appropriate."""
+        # Arrange
+        X_target, X_source = sample_data
+        model = PiecewiseDirectStandardization(n_components=15, storage="sparse")
+
+        # Act
+        model.fit(X_target, X_source=X_source)
+
+        # Assert
+        assert isinstance(model.T_, csr_matrix)
 
 
 class TestTransform:

--- a/tests/adaptation/test_spectral_space_transform.py
+++ b/tests/adaptation/test_spectral_space_transform.py
@@ -51,6 +51,7 @@ class TestFit:
         assert hasattr(model, "n_features_in_")
         assert hasattr(model, "p1_")
         assert hasattr(model, "p2_")
+        assert hasattr(model, "p2_inv_")
         assert model.p1_.shape == model.p2_.shape
         assert model.n_features_in_ == X_target.shape[1]
 
@@ -243,7 +244,7 @@ class TestNumericalCorrectness:
         np.testing.assert_array_equal(model1.p2_, model2.p2_)
 
     def test_n_components_exceeds_n_samples(self):
-        """Verifies n_components > n_samples - 1 rises ValueError."""
+        """Verifies n_components > n_samples - 1 raises ValueError."""
         # Arrange
         rng = np.random.default_rng(17)
         X_target = rng.normal(size=(8, 20))
@@ -255,7 +256,7 @@ class TestNumericalCorrectness:
             model.fit(X_target, X_source=X_source)
 
     def test_n_components_exceeds_n_features(self):
-        """Verifies n_components > 2*n_features rises ValueError."""
+        """Verifies n_components > 2*n_features raises ValueError."""
         # Arrange
         rng = np.random.default_rng(17)
         X_target = rng.normal(size=(20, 8))

--- a/tests/adaptation/test_spectral_space_transform.py
+++ b/tests/adaptation/test_spectral_space_transform.py
@@ -1,0 +1,254 @@
+"""
+Test for SpectralSpaceTransform
+"""
+
+# Authors: Ruggero Guerrini
+# License: MIT
+
+import re
+
+import numpy as np
+import pytest
+import sklearn
+from sklearn.cross_decomposition import PLSRegression
+from sklearn.exceptions import NotFittedError
+from sklearn.model_selection import GridSearchCV
+from sklearn.pipeline import Pipeline
+from sklearn.utils.estimator_checks import check_estimator
+
+from chemotools.adaptation._spectral_space_transform import (
+    SpectralSpaceTransform,
+)
+from chemotools.derivative import SavitzkyGolay
+from tests.adaptation.conftest import data_diff
+
+
+class TestSklearnCompliance:
+    """Tests for sklearn estimator API compliance."""
+
+    def test_compliance_SpectralSpaceTransform(self):
+        """Verifies that SpectralSpaceTransform passes all sklearn estimator
+        checks."""
+        # Arrange
+        transformer = SpectralSpaceTransform()
+
+        # Act & Assert
+        check_estimator(transformer)
+
+
+class TestFit:
+    """Tests for the fit method behavior."""
+
+    def test_fit_sets_attributes(self, sample_data):
+        """Verifies that fit stores the required fitted attributes with valid values."""
+        # Arrange
+        X_target, X_source = sample_data
+
+        # Act
+        model = SpectralSpaceTransform().fit(X_target, X_source=X_source)
+
+        # Assert - Check attributes exist with correct shapes
+        assert hasattr(model, "n_features_in_")
+        assert hasattr(model, "p1_")
+        assert hasattr(model, "p2_")
+        assert model.p1_.shape == model.p2_.shape
+        assert model.n_features_in_ == X_target.shape[1]
+
+        # Assert - Check values are finite and reasonable
+        assert np.all(np.isfinite(model.p1_))
+        assert np.all(np.isfinite(model.p2_))
+
+    def test_fit_raises_on_shape_mismatch(self, sample_data):
+        """Verifies fit raises ValueError when X and X_source have different shapes."""
+        # Arrange
+        X_target, X_source = sample_data
+        model = SpectralSpaceTransform()
+
+        # Act & Assert
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "X and X_source must have the same shape, got X=(100, 20) and "
+                "X_source=(99, 20)."
+            ),
+        ):
+            model.fit(X_target, X_source=X_source[:-1, :])
+
+
+class TestTransform:
+    """Tests for the transform method behavior."""
+
+    def test_transform_preserves_shape(self, sample_data):
+        """Verifies that the output shape matches both input X and X_source."""
+        # Arrange
+        X_target, X_source = sample_data
+        model = SpectralSpaceTransform().fit(X_target, X_source=X_source)
+
+        # Act
+        X_transformed = model.transform(X_target)
+
+        # Assert
+        assert X_transformed.shape == X_source.shape
+        assert X_transformed.shape == X_target.shape
+
+    def test_transform_improves_match_to_target(self, sample_data):
+        """Verifies that transformation reduces the distance to the source instrument
+        data."""
+        # Arrange
+        X_target, X_source = sample_data
+        model = SpectralSpaceTransform().fit(X_target, X_source=X_source)
+
+        # Act
+        X_transformed = model.transform(X_target)
+        before = data_diff(X_target, X_source)
+        after = data_diff(X_transformed, X_source)
+
+        # Assert
+        assert after < before
+
+    def test_transform_before_fit_raises(self, sample_data):
+        """Verifies that calling transform before fit raises NotFittedError."""
+        # Arrange
+        X_target, _ = sample_data
+        model = SpectralSpaceTransform()
+
+        # Act & Assert
+        with pytest.raises(NotFittedError):
+            model.transform(X_target)
+
+    def test_transform_does_not_modify_input(self, sample_data):
+        """Verifies that fit and transform do not mutate the input arrays."""
+        # Arrange
+        X_target, X_source = sample_data
+        X_target_original = X_target.copy()
+        X_source_original = X_source.copy()
+
+        # Act
+        model = SpectralSpaceTransform().fit(X_target, X_source=X_source)
+        model.transform(X_target)
+
+        # Assert
+        np.testing.assert_array_equal(X_target, X_target_original)
+        np.testing.assert_array_equal(X_source, X_source_original)
+
+
+class TestNumericalCorrectness:
+    """Tests for numerical correctness and regression testing.
+
+    These tests verify that the algorithm produces expected numerical outputs.
+    They serve as regression tests to catch unintended changes in functionality.
+    """
+
+    def test_transform_output_characteristics(self):
+        """Verifies that transform output has expected characteristics."""
+        # Arrange
+        rng = np.random.default_rng(42)
+        X_target = rng.normal(size=(20, 8))
+        X_source = X_target * 2.0 + rng.normal(0, 0.1, size=(20, 8))
+
+        model = SpectralSpaceTransform(
+            n_components=2,
+        )
+        model.fit(X_target, X_source=X_source)
+
+        # Act
+        X_test = rng.normal(size=(5, 8))
+        X_transformed = model.transform(X_test)
+
+        # Assert - Check output properties
+        assert X_transformed.shape == X_test.shape
+        assert np.all(np.isfinite(X_transformed))
+        assert np.abs(X_transformed).mean() > 0  # Non-zero output
+        assert np.abs(X_transformed).max() < 100  # Reasonable magnitude
+
+    def test_transformation_is_reproducible(self):
+        """Verifies that same inputs always produce same outputs."""
+        # Arrange
+        rng = np.random.default_rng(99)
+        X_target = rng.normal(size=(25, 12))
+        X_source = X_target * 1.3 + rng.normal(0, 0.08, size=(25, 12))
+        X_test = rng.normal(size=(10, 12))
+
+        # Act - Fit and transform twice
+        model1 = SpectralSpaceTransform(n_components=2)
+        model1.fit(X_target, X_source=X_source)
+        result1 = model1.transform(X_test)
+
+        model2 = SpectralSpaceTransform(n_components=2)
+        model2.fit(X_target, X_source=X_source)
+        result2 = model2.transform(X_test)
+
+        # Assert - Results should be bit-for-bit identical
+        np.testing.assert_array_equal(result1, result2)
+        np.testing.assert_array_equal(model1.p1_, model2.p1_)
+        np.testing.assert_array_equal(model1.p2_, model2.p2_)
+
+
+class TestEdgeCases:
+    """Tests for edge cases and special scenarios."""
+
+    def test_identity_transformation_when_X_source_is_none(self):
+        """Verifies that fitting with X_source=None results in identity
+        transformation."""
+        # Arrange
+        rng = np.random.default_rng(42)
+        X = rng.normal(size=(50, 10))
+        model = SpectralSpaceTransform()
+
+        # Act - fit with X_source=None should trigger identity transformation
+        with pytest.warns(UserWarning, match="identity transformation"):
+            model.fit(X, X_source=None)
+
+        X_transformed = model.transform(X)
+
+        # Assert - should return X unchanged
+        np.testing.assert_array_equal(X_transformed, X)
+        assert hasattr(model, "x_source_provided_")
+        assert model.x_source_provided_ is False
+
+
+class TestPipeline:
+    """Tests for sklearn Pipeline and metadata routing integration."""
+
+    def test_pipeline_gridsearchcv_pls_metadata_routing(self, sample_data):
+        """Verifies that X_source metadata routing works inside a Pipeline with
+        GridSearchCV."""
+        # Arrange
+        X_target, X_source = sample_data
+        rng = np.random.default_rng(42)
+        y_concentration = rng.normal(size=(100, 1))
+
+        sklearn.set_config(enable_metadata_routing=True)
+        try:
+            pipe = Pipeline(
+                [
+                    ("scaler", SavitzkyGolay()),
+                    (
+                        "model",
+                        SpectralSpaceTransform().set_fit_request(X_source=True),
+                    ),
+                    ("pls", PLSRegression()),
+                ]
+            )
+            param_grid = {
+                "scaler__window_length": [15, 25],
+                "scaler__polyorder": [2, 3],
+                "scaler__deriv": [1, 2],
+                "model__n_components": [2, 3, 5],
+                "pls__n_components": [2, 3],
+            }
+            grid = GridSearchCV(pipe, param_grid, cv=3, error_score="raise")
+
+            # Act
+            grid.fit(X_target, y_concentration, X_source=X_source)
+            X_test = rng.normal(size=(10, 20))
+            y_pred = grid.best_estimator_.predict(X_test)
+
+            # Assert
+            assert grid.best_estimator_ is not None
+            assert hasattr(grid.best_estimator_, "named_steps")
+            assert y_pred.shape == (10, 1)
+
+        finally:
+            # Cleanup - reset config to avoid affecting other tests
+            sklearn.set_config(enable_metadata_routing=False)

--- a/tests/adaptation/test_spectral_space_transform.py
+++ b/tests/adaptation/test_spectral_space_transform.py
@@ -70,8 +70,8 @@ class TestFit:
         with pytest.raises(
             ValueError,
             match=re.escape(
-                "X and X_source must have the same shape, got X=(100, 20) and "
-                "X_source=(99, 20)."
+                "X and X_source must have the same shape, got X=(100, 50) and "
+                "X_source=(99, 50)."
             ),
         ):
             model.fit(X_target, X_source=X_source[:-1, :])
@@ -404,7 +404,7 @@ class TestPipeline:
 
             # Act
             grid.fit(X_target, y_concentration, X_source=X_source)
-            X_test = rng.normal(size=(10, 20))
+            X_test = rng.normal(size=(10, 50))
             y_pred = grid.best_estimator_.predict(X_test)
 
             # Assert

--- a/tests/adaptation/test_spectral_space_transform.py
+++ b/tests/adaptation/test_spectral_space_transform.py
@@ -139,6 +139,65 @@ class TestNumericalCorrectness:
     They serve as regression tests to catch unintended changes in functionality.
     """
 
+    def test_snapshot_transform_output(self):
+        """Snapshot test: verifies transform output matches reference values.
+
+        This is a golden/snapshot test with hardcoded expected output.
+        If this test fails after code changes, verify the change is intentional.
+        Reference output generated from v0.4.0 implementation.
+        """
+        # Arrange - Fixed data (do not change!)
+        rng = np.random.default_rng(123)
+        X_target = rng.normal(size=(15, 8))
+        X_source = X_target * 1.3 + rng.normal(0, 0.08, size=(15, 8))
+        X_test = rng.normal(size=(3, 8))
+
+        # Expected reference output
+        expected_output = np.array(
+            [
+                [
+                    0.33766514,
+                    1.20500713,
+                    -0.79705418,
+                    1.084966,
+                    -0.70751184,
+                    0.1530644,
+                    -0.14018872,
+                    0.0766695,
+                ],
+                [
+                    1.45796125,
+                    1.04039632,
+                    -0.63244578,
+                    -2.8429184,
+                    0.92801337,
+                    0.70227497,
+                    0.09480183,
+                    -0.52365807,
+                ],
+                [
+                    1.72038539,
+                    -2.24518931,
+                    -1.05896606,
+                    -1.38621342,
+                    0.19916246,
+                    -0.4604514,
+                    2.23600502,
+                    0.16752753,
+                ],
+            ]
+        )
+
+        # Act
+        model = SpectralSpaceTransform(
+            n_components=2,
+        )
+        model.fit(X_target, X_source=X_source)
+        output = model.transform(X_test)
+
+        # Assert - Output should match reference within tolerance
+        np.testing.assert_allclose(output, expected_output, rtol=1e-6, atol=1e-8)
+
     def test_transform_output_characteristics(self):
         """Verifies that transform output has expected characteristics."""
         # Arrange
@@ -182,6 +241,45 @@ class TestNumericalCorrectness:
         np.testing.assert_array_equal(result1, result2)
         np.testing.assert_array_equal(model1.p1_, model2.p1_)
         np.testing.assert_array_equal(model1.p2_, model2.p2_)
+    def test_n_components_exceeds_n_samples(self):
+        """Verifies n_components > n_samples - 1 rises ValueError."""
+        # Arrange
+        rng = np.random.default_rng(17)
+        X_target = rng.normal(size=(8, 20))
+        X_source = X_target * 2.0 + rng.normal(0, 0.1, size=(8, 20))
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="n_components=40 is too large"):
+            model = SpectralSpaceTransform(n_components=40)
+            model.fit(X_target, X_source=X_source)
+
+
+    def test_n_components_exceeds_n_features(self):
+        """Verifies n_components > 2*n_features rises ValueError."""
+        # Arrange
+        rng = np.random.default_rng(17)
+        X_target = rng.normal(size=(20, 8))
+        X_source = X_target * 2.0 + rng.normal(0, 0.1, size=(20, 8))
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="n_components=17 is too large"):
+            model = SpectralSpaceTransform(n_components=17)
+            model.fit(X_target, X_source=X_source)
+
+
+    def test_n_components_at_boundary_is_valid(self):
+        """Verifies n_components == min(n_samples-1, n_features) is accepted."""
+        # Arrange
+        rng = np.random.default_rng(17)
+        X_target = rng.normal(size=(20, 8))
+        X_source = X_target * 2.0 + rng.normal(0, 0.1, size=(20, 8))
+
+        # Act
+        model = SpectralSpaceTransform(n_components=9)
+        model.fit(X_target, X_source=X_source)
+
+        # Assert
+        assert model.transform(X_target).shape == X_target.shape
 
 
 class TestEdgeCases:

--- a/tests/adaptation/test_spectral_space_transform.py
+++ b/tests/adaptation/test_spectral_space_transform.py
@@ -241,6 +241,7 @@ class TestNumericalCorrectness:
         np.testing.assert_array_equal(result1, result2)
         np.testing.assert_array_equal(model1.p1_, model2.p1_)
         np.testing.assert_array_equal(model1.p2_, model2.p2_)
+
     def test_n_components_exceeds_n_samples(self):
         """Verifies n_components > n_samples - 1 rises ValueError."""
         # Arrange
@@ -253,7 +254,6 @@ class TestNumericalCorrectness:
             model = SpectralSpaceTransform(n_components=40)
             model.fit(X_target, X_source=X_source)
 
-
     def test_n_components_exceeds_n_features(self):
         """Verifies n_components > 2*n_features rises ValueError."""
         # Arrange
@@ -265,7 +265,6 @@ class TestNumericalCorrectness:
         with pytest.raises(ValueError, match="n_components=17 is too large"):
             model = SpectralSpaceTransform(n_components=17)
             model.fit(X_target, X_source=X_source)
-
 
     def test_n_components_at_boundary_is_valid(self):
         """Verifies n_components == min(n_samples-1, n_features) is accepted."""

--- a/tests/adaptation/test_spectral_space_transform.py
+++ b/tests/adaptation/test_spectral_space_transform.py
@@ -6,6 +6,7 @@ Test for SpectralSpaceTransform
 # License: MIT
 
 import re
+import warnings
 
 import numpy as np
 import pytest
@@ -49,15 +50,15 @@ class TestFit:
 
         # Assert - Check attributes exist with correct shapes
         assert hasattr(model, "n_features_in_")
-        assert hasattr(model, "p1_")
-        assert hasattr(model, "p2_")
-        assert hasattr(model, "p2_inv_")
-        assert model.p1_.shape == model.p2_.shape
+        assert hasattr(model, "P1_")
+        assert hasattr(model, "P2_")
+        assert hasattr(model, "T_")
+        assert model.P1_.shape == model.P2_.shape
         assert model.n_features_in_ == X_target.shape[1]
 
         # Assert - Check values are finite and reasonable
-        assert np.all(np.isfinite(model.p1_))
-        assert np.all(np.isfinite(model.p2_))
+        assert np.all(np.isfinite(model.P1_))
+        assert np.all(np.isfinite(model.P2_))
 
     def test_fit_raises_on_shape_mismatch(self, sample_data):
         """Verifies fit raises ValueError when X and X_source have different shapes."""
@@ -145,7 +146,8 @@ class TestNumericalCorrectness:
 
         This is a golden/snapshot test with hardcoded expected output.
         If this test fails after code changes, verify the change is intentional.
-        Reference output generated from v0.4.0 implementation.
+        Reference output generated with with_mean=True, with_std=False
+        (current defaults)
         """
         # Arrange - Fixed data (do not change!)
         rng = np.random.default_rng(123)
@@ -153,38 +155,38 @@ class TestNumericalCorrectness:
         X_source = X_target * 1.3 + rng.normal(0, 0.08, size=(15, 8))
         X_test = rng.normal(size=(3, 8))
 
-        # Expected reference output
+        # Expected reference output (generated with with_mean=True, with_std=False)
         expected_output = np.array(
             [
                 [
-                    0.33766514,
-                    1.20500713,
-                    -0.79705418,
-                    1.084966,
-                    -0.70751184,
-                    0.1530644,
-                    -0.14018872,
-                    0.0766695,
+                    0.34477441,
+                    1.11211523,
+                    -0.58705409,
+                    1.17686593,
+                    -0.6932544,
+                    0.25381937,
+                    -0.05075614,
+                    -0.06602294,
                 ],
                 [
-                    1.45796125,
-                    1.04039632,
-                    -0.63244578,
-                    -2.8429184,
-                    0.92801337,
-                    0.70227497,
-                    0.09480183,
-                    -0.52365807,
+                    1.46727768,
+                    0.93425806,
+                    -0.36373723,
+                    -2.72465293,
+                    0.94963568,
+                    0.82598552,
+                    0.19712279,
+                    -0.71140041,
                 ],
                 [
-                    1.72038539,
-                    -2.24518931,
-                    -1.05896606,
-                    -1.38621342,
-                    0.19916246,
-                    -0.4604514,
-                    2.23600502,
-                    0.16752753,
+                    1.68110708,
+                    -2.3451825,
+                    -0.82396761,
+                    -1.33091796,
+                    0.18088225,
+                    -0.43624381,
+                    2.27549503,
+                    0.08766347,
                 ],
             ]
         )
@@ -240,8 +242,9 @@ class TestNumericalCorrectness:
 
         # Assert - Results should be bit-for-bit identical
         np.testing.assert_array_equal(result1, result2)
-        np.testing.assert_array_equal(model1.p1_, model2.p1_)
-        np.testing.assert_array_equal(model1.p2_, model2.p2_)
+        np.testing.assert_array_equal(model1.P1_, model2.P1_)
+        np.testing.assert_array_equal(model1.P2_, model2.P2_)
+        np.testing.assert_array_equal(model1.T_, model2.T_)
 
     def test_n_components_exceeds_n_samples(self):
         """Verifies n_components > n_samples - 1 raises ValueError."""
@@ -284,6 +287,68 @@ class TestNumericalCorrectness:
 
 class TestEdgeCases:
     """Tests for edge cases and special scenarios."""
+
+    def test_constant_target_feature_warns(self):
+        """Verifies a warning is raised when X (target) has a constant feature
+        and with_std=True."""
+        # Arrange
+        rng = np.random.default_rng(42)
+        X_target = rng.normal(size=(20, 5))
+        X_target[:, 2] = 3.0  # make feature 2 constant
+        X_source = rng.normal(size=(20, 5))
+
+        # Act & Assert
+        with pytest.warns(UserWarning, match="X \\(target\\) has 1 constant feature"):
+            SpectralSpaceTransform(with_std=True).fit(X_target, X_source=X_source)
+
+    def test_constant_source_feature_warns(self):
+        """Verifies a warning is raised when X_source has a constant feature
+        and with_std=True."""
+        # Arrange
+        rng = np.random.default_rng(42)
+        X_target = rng.normal(size=(20, 5))
+        X_source = rng.normal(size=(20, 5))
+        X_source[:, 0] = 0.0  # make feature 0 constant
+
+        # Act & Assert
+        with pytest.warns(UserWarning, match="X_source has 1 constant feature"):
+            SpectralSpaceTransform(with_std=True).fit(X_target, X_source=X_source)
+
+    def test_constant_feature_std_clamped_to_one(self):
+        """Verifies that the stored std for constant features is 1, not 0."""
+        # Arrange
+        rng = np.random.default_rng(42)
+        X_target = rng.normal(size=(20, 5))
+        X_target[:, 1] = 7.0
+        X_source = rng.normal(size=(20, 5))
+        X_source[:, 3] = -2.0
+
+        # Act
+        with pytest.warns(UserWarning):
+            model = SpectralSpaceTransform(with_std=True).fit(
+                X_target, X_source=X_source
+            )
+
+        # Assert - constant features must have std == 1, not 0
+        assert model.X_target_std_[1] == 1.0
+        assert model.X_source_std_[3] == 1.0
+        # Non-constant features must retain their real std
+        assert model.X_target_std_[0] != 1.0
+        assert model.X_source_std_[0] != 1.0
+
+    def test_no_warning_when_with_std_false(self):
+        """Verifies no zero-variance warning is raised when with_std=False,
+        even if features are constant."""
+        # Arrange
+        rng = np.random.default_rng(42)
+        X_target = rng.normal(size=(20, 5))
+        X_target[:, 0] = 5.0
+        X_source = rng.normal(size=(20, 5))
+
+        # Act & Assert - no UserWarning about constant features
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            SpectralSpaceTransform(with_std=False).fit(X_target, X_source=X_source)
 
     def test_identity_transformation_when_X_source_is_none(self):
         """Verifies that fitting with X_source=None results in identity

--- a/tests/adaptation/test_spectral_space_transform.py
+++ b/tests/adaptation/test_spectral_space_transform.py
@@ -52,7 +52,7 @@ class TestFit:
         assert hasattr(model, "n_features_in_")
         assert hasattr(model, "P1_")
         assert hasattr(model, "P2_")
-        assert hasattr(model, "T_")
+        assert hasattr(model, "A_")
         assert model.P1_.shape == model.P2_.shape
         assert model.n_features_in_ == X_target.shape[1]
 


### PR DESCRIPTION
## Why is this change needed?

Adds the Spectral Space Transform (SST) transformer to the `chemotools.adaptation`
module. SST is a linear domain adaptation method that aligns target spectral data
to a source (reference) domain via SVD of the concatenated source-target matrix.
This extends the adaptation module alongside the existing DS and PDS transformers.


## Type of change

- [x] New feature

## Description

Implementation of `SpectralSpaceTransform` following the method described in:

> Du et al. (2011). Maintaining the predictive abilities of multivariate calibration models by spectral space transformation. 
> Analytica Chimica Acta, 690(1), 64–70.
> https://doi.org/10.1016/j.aca.2011.02.014

### What was added
- `SpectralSpaceTransform` transformer in `chemotools/adaptation/_spectral_space_transform.py`
- Full sklearn API compliance (`fit`, `transform`, `fit_transform`)
- Identity fallback when `X_source=None`

### Tests added
- sklearn estimator compliance
- fit attributes and shape checks
- boundary and edge case validation for `n_components`
- Pipeline + GridSearchCV + metadata routing integration