### PR TITLE
271 feature implementation of columntransformer support

### DIFF
--- a/chemotools/_optional.py
+++ b/chemotools/_optional.py
@@ -7,7 +7,7 @@ checking and importing packages that are not listed in the core
 
 from __future__ import annotations
 
-from importlib import import_module
+import importlib
 from types import ModuleType
 
 
@@ -43,7 +43,7 @@ def import_optional_dependency(
         When *package_name* cannot be imported.
     """
     try:
-        return import_module(package_name)
+        return importlib.import_module(package_name)
     except (ModuleNotFoundError, ImportError) as exc:
         # Only intercept errors that originate from *this* package.
         if (

--- a/chemotools/inspector/_pls_regression_inspector.py
+++ b/chemotools/inspector/_pls_regression_inspector.py
@@ -365,7 +365,7 @@ class PLSRegressionInspector(
             _, y = self._get_raw_data(dataset)
 
             # Use transform with Y to get Y-scores
-            _, y_scores = self.estimator.transform(X_preprocessed, y, return_y = True)
+            _, y_scores = self.estimator.transform(X_preprocessed, y, return_y=True)
             self._y_scores_cache[dataset] = y_scores
         return self._y_scores_cache[dataset]
 

--- a/chemotools/inspector/_pls_regression_inspector.py
+++ b/chemotools/inspector/_pls_regression_inspector.py
@@ -365,7 +365,7 @@ class PLSRegressionInspector(
             _, y = self._get_raw_data(dataset)
 
             # Use transform with Y to get Y-scores
-            _, y_scores = self.estimator.transform(X_preprocessed, y)
+            _, y_scores = self.estimator.transform(X_preprocessed, y, return_y = True)
             self._y_scores_cache[dataset] = y_scores
         return self._y_scores_cache[dataset]
 

--- a/chemotools/inspector/_pls_regression_inspector.py
+++ b/chemotools/inspector/_pls_regression_inspector.py
@@ -365,7 +365,7 @@ class PLSRegressionInspector(
             _, y = self._get_raw_data(dataset)
 
             # Use transform with Y to get Y-scores
-            _, y_scores = self.estimator.transform(X_preprocessed, y, return_y=True)
+            _, y_scores = self.estimator.transform(X_preprocessed, y)
             self._y_scores_cache[dataset] = y_scores
         return self._y_scores_cache[dataset]
 

--- a/chemotools/regression/_pls_regression.py
+++ b/chemotools/regression/_pls_regression.py
@@ -231,9 +231,12 @@ class PLSRegression(_SklearnPLSRegression):
             Y transformed into the latent space (Y-scores), returned if `return_y=True`.
         """
         if return_y:
+            if y is None:
+                 raise ValueError("return_y=True requires `y` to be provided.")
             return super().transform(X, y=y, copy=copy)
-        else:
-            return super().transform(X, copy=copy)
+        # else:
+        #     return super().transform(X, copy=copy)
+        return super().transform(X, copy=copy)
 
     def get_feature_names_out(
         self, input_features: list[str] | None = None
@@ -257,7 +260,11 @@ class PLSRegression(_SklearnPLSRegression):
         np.ndarray of shape (n_components,)
             - Latent variable names
         """
-        return np.asarray([f"LV{i + 1}" for i in range(self.n_components)])
+        from sklearn.utils.validation import check_is_fitted
+
+        check_is_fitted(self)
+        return np.asarray([f"LV{i + 1}" for i in range(self.n_components)],
+                          dtype=object)
 
     def _calculate_explained_variance_deflation(
         self, X, y

--- a/chemotools/regression/_pls_regression.py
+++ b/chemotools/regression/_pls_regression.py
@@ -201,7 +201,13 @@ class PLSRegression(_SklearnPLSRegression):
 
         return self
 
-    def transform(self, X: np.ndarray, y: np.ndarray | None = None, copy: bool = True):
+    def transform(
+        self,
+        X: np.ndarray,
+        y: np.ndarray | None = None,
+        copy: bool = True,
+        return_y: bool = False,
+    ) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
         """Apply dimensionality reduction to X.
 
         Projects X onto the latent components found during fitting.
@@ -214,13 +220,44 @@ class PLSRegression(_SklearnPLSRegression):
             Target vectors. Only used to transform Y when provided.
         copy : bool, default=True
             Whether to copy X and Y, or perform in-place normalization.
+        return_y : bool, default=False
+            Whether to return transformed Y (Y-scores) along with X-scores.
 
         Returns
         -------
         X_scores : ndarray of shape (n_samples, n_components)
             X transformed into the latent space (X-scores).
+        Y_scores : ndarray of shape (n_samples, n_components), optional
+            Y transformed into the latent space (Y-scores), returned if `return_y=True`.
         """
-        return super().transform(X, y=y, copy=copy)
+        if return_y:
+            return super().transform(X, y=y, copy=copy)
+        else:
+            return super().transform(X, copy=copy)
+
+    def get_feature_names_out(
+        self, input_features: list[str] | None = None
+    ) -> np.ndarray:
+        """Return the feature names for the transformed data.
+
+        This returns a list [LV1, LV2, ..., LV{n_components}] of feature names.
+
+        This functions is used when the sklearn
+        .set_output("pandas")/set_config(transform_output="pandas")
+        feature is used.
+
+        Parameters
+        ----------
+        input_features : list of str, optional
+            Input feature names. Ignored in this implementation since output features
+            are fixed. Used for compatibility with sklearn's API.
+
+        Returns
+        -------
+        np.ndarray of shape (n_components,)
+            - Latent variable names
+        """
+        return np.asarray([f"LV{i + 1}" for i in range(self.n_components)])
 
     def _calculate_explained_variance_deflation(
         self, X, y

--- a/tests/inspector/test_pls_regression_inspector.py
+++ b/tests/inspector/test_pls_regression_inspector.py
@@ -844,6 +844,25 @@ class TestAdditionalCoverage:
         for fig in figures.values():
             plt.close(fig)
 
+    def test_get_y_scores(self, fitted_pls, regression_data):
+        # Arrange
+        X_train, y_train = regression_data["train"]
+        inspector = PLSRegressionInspector(fitted_pls, X_train, y_train)
+
+        # Act
+        y_scores_inspector = inspector.get_y_scores("train")
+        _, y_scores_pls = fitted_pls.transform(X_train, y_train)
+
+        # Assert
+        np.testing.assert_array_almost_equal(
+            y_scores_inspector,
+            y_scores_pls,
+            decimal=10,
+            err_msg="Inpsector y scores should match the fitted_pls y_scores",
+        )
+
+
+
 
 class TestValidationPropagation:
     def test_y_length_mismatch_raises(self, fitted_pls, regression_data):

--- a/tests/regression/test_pls_regression.py
+++ b/tests/regression/test_pls_regression.py
@@ -1,8 +1,11 @@
 """Tests for enhanced PLSRegression with automatic variance calculation."""
 
 import numpy as np
+import pandas as pd
 import pytest
+from sklearn.compose import ColumnTransformer
 from sklearn.cross_decomposition import PLSRegression as SklearnPLSRegression
+from sklearn.pipeline import Pipeline
 from sklearn.utils.estimator_checks import check_estimator
 
 from chemotools.regression import PLSRegression
@@ -183,6 +186,45 @@ class TestPLSRegressionCompatibility:
             decimal=10,
             err_msg="Multivariate predictions should match sklearn",
         )
+
+    def test_works_with_column_transformer(self):
+        # Arrange
+        np.random.seed(42)
+        X = np.random.randn(100, 50)
+        y = np.random.randn(100)
+        cols = [f"c{i}" for i in range(X.shape[1])]
+        df_x = pd.DataFrame(X, columns=cols)
+        df_y = pd.DataFrame(y, columns=["y"])
+
+        df_x.insert(0, "sample_id", [f"S{i:04d}" for i in range(len(df_x))])
+        df_x.insert(
+            1,
+            "region",
+            np.random.choice(["North", "South", "East", "West"], size=len(df_x)),
+        )
+
+        METADATA_COLS = df_x.select_dtypes(exclude="number").columns.tolist()
+        FEATURE_COLS = df_x.select_dtypes(include="number").columns.tolist()
+        N_COMPONENTS = 3
+
+        expected_columns = ["sample_id", "region"]
+        expected_columns += [f"LV{i + 1}" for i in range(N_COMPONENTS)]
+
+        # Act
+        pipeline = Pipeline([("pls", PLSRegression(n_components=N_COMPONENTS))])
+
+        transformer = ColumnTransformer(
+            transformers=[
+                ("metadata", "passthrough", METADATA_COLS),
+                ("features", pipeline, FEATURE_COLS),
+            ],
+            verbose_feature_names_out=False,
+        ).set_output(transform="pandas")
+
+        df_out = transformer.fit_transform(df_x, df_y)
+
+        # Assert
+        assert df_out.columns.tolist() == expected_columns
 
 
 class TestPLSRegressionVarianceCalculation:

--- a/tests/utils/test_optional_dependencies.py
+++ b/tests/utils/test_optional_dependencies.py
@@ -52,7 +52,7 @@ def test_import_optional_dependency_real_optional(monkeypatch):
             raise ImportError("No module named 'pandas'")
         return real_import(name, *args, **kwargs)
 
-    monkeypatch.setattr("builtins.__import__", fake_import)
+    monkeypatch.setattr("importlib.import_module", fake_import)
 
     with pytest.raises(ImportError) as excinfo:
         import_optional_dependency("pandas", caller_name="test_loader")


### PR DESCRIPTION
## Summary

<!-- What does this PR change? Keep it short and concrete. -->
- Updates the `PLSRegression` transformer to add compatibility with sklearn's `ColumnTransformer`.
- When setting `transform_out="pandas"`, the `PLSRegression` transformer will output scores as a dataframe with columns `LV1` to `LVn`.
- This PR also addresses issues with the `test_optional_dependencies` test failing.

## Why is this change needed?

<!-- Explain the problem, motivation, or user value. -->
- This change will allow the passthrough of metadata when creating a pipeline to process pandas dataframes.

## Closes

<!-- Use GitHub keywords so issues are automatically closed when this PR is merged.-->
- Closes #271 


## Related issues

<!-- Optional: issues that are relevant but NOT closed by this PR -->
- 

## Type of change

<!-- Mark all that apply -->
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Documentation update
- [x] Tests only
- [ ] CI / DevOps / tooling
- [ ] Dependency update
- [ ] Breaking change

## What changed?

<!-- Describe the implementation at a reviewable level. -->
- Updated `chemotools/regression/_pls_regression.py`:
    - Defined `get_feature_names_out` method to return an array `["LV1" ... "LVn"]` to serve as column names for scores dataframe.
    - Updated the `transform` method to add a flag to define if `y_scores` should be returned by the method.
- Updated `chemotools/tests/regression/test_pls_regression.py`:
    - Added `test_works_with_column_transformer` test to ensure that the `PLSRegression` transformer is compatible with the `ColumnTransformer`.
- Updated `chemotools/_optional.py` and `chemotools/tests/utils/test_optional_dependencies.py` to fix issues with the `test_import_optional_dependency_real_optional` test.

## What did NOT change?

<!-- Helps reviewers understand scope boundaries and avoid assumption drift. -->
- No other transformers other than `PLSRegression` were modified.

## API and compatibility impact

<!-- Complete only if relevant -->
- [ ] No public API changes
- [ ] Public API added
- [x] Public API changed
- [ ] Deprecation introduced
- [ ] Breaking change introduced

### Notes
- scikit-learn API compatibility: PLSRegression should still be fully compliant with SKLearn
- Affected modules/classes/functions:
    - `PLSRegression` class in `chemotools/regression/_pls_regression.py` was updated.
    -  `import_optional_dependency` function in `chemotools/_optional.py` was updated.
- Backward compatibility considerations:
    - Instances where `PLSRegression` transformer is used and expect `y_scores` to be returned should be modified to include the `return_y=True` flag.

## Validation

<!-- Mark what you actually ran locally -->
- [x] `task format-check`
- [x] `task lint`
- [x] `task spelling`
- [x] `task type-check`
- [x] `task test`
- [x] `task coverage`
- [x] `task test:matrix`
- [ ] `task docs:check`
- [ ] `task build`

### Validation notes
<!-- Mention anything intentionally skipped and why -->
- `test_import_optional_dependency_real_optional` was originally failing, but issue was addressed by updating the test and the `import_optional_dependency` function.
- Failure observed when running `task docs:check`

## Tests

<!-- Describe the tests added or updated -->
- [x] Added new tests
- [x] Updated existing tests
- [ ] No tests added because this PR only changes docs / CI / metadata

### Test coverage details
- Relevant test files:
    -  `chemotools/tests/utils/test_optional_dependencies.py`
    -  `chemotools/tests/regression/test_pls_regression.py`
- Edge cases covered:
    - Use of `PLSRegression` in a pipeline with `ColumnTransformer` where the `transform_output="pandas"`
- Numerical / estimator behavior checked: N/A

## Documentation

- [ ] Docs updated
- [ ] Docstrings updated
- [ ] No docs update needed

### Documentation notes
<!-- Mention examples, API docs, tutorials, or user-facing docs touched -->
- Updates to methods and functions were reflected in the previously existing docstring.

## Dependency / build / CI impact

<!-- Complete if relevant -->
- [x] No dependency changes
- [ ] Runtime dependency change
- [ ] Dev dependency change
- [ ] GitHub Actions / CI changed
- [ ] Build/release process changed

### Notes
- 

## Reviewer focus

<!-- Tell reviewers where to spend time -->
Please focus on:
- The updated `transform`  and the new `get_feature_names_out` methods for `PLSRegression`.
- The new/updated tests for `utils` and `PLSRegression`.

## Screenshots / logs / benchmark output

<!-- Optional but encouraged for docs, CI, performance, or UX-related changes -->
<details>
<summary>Details</summary>
</details>

```text
```

## Checklist
- [x] I linked the relevant issue(s) or explained why none exists
- [x] I kept this PR scoped to a single purpose
- [x] I added or updated tests where appropriate
- [x] I updated documentation where appropriate
- [x] I verified the change locally using the relevant tasks above
- [x] I considered backward compatibility and public API impact
- [x] I am ready for review