### PR TITLE
feat(augmentation): Add min_shift parameter to FractionalShift #284

### DIFF
--- a/chemotools/augmentation/_fractional_shift.py
+++ b/chemotools/augmentation/_fractional_shift.py
@@ -33,6 +33,11 @@ class FractionalShift(
         Maximum absolute shift applied to each signal.
         A random shift is drawn uniformly from [-shift, +shift].
 
+    min_shift : float or None, default=None
+        Minimum absolute shift applied to each signal. When provided, the
+        shift is drawn uniformly  from the union of [-shift, -min_shift]
+        and [min_shift, shift].
+
     padding_mode : {'zeros', 'constant', 'wrap', 'extend',
         'mirror', 'linear'}, default='linear'
         Padding strategy for extrapolated values.
@@ -64,6 +69,7 @@ class FractionalShift(
 
     _parameter_constraints: dict = {
         "shift": [Interval(Real, 0, None, closed="both")],
+        "min_shift": [None, Interval(Real, 0, None, closed="both")],
         "padding_mode": [
             StrOptions({"zeros", "constant", "extend", "mirror", "linear"})
         ],
@@ -74,6 +80,7 @@ class FractionalShift(
     def __init__(
         self,
         shift: float = 0.0,
+        min_shift: Optional[float] = None,
         padding_mode: Literal[
             "zeros", "constant", "extend", "mirror", "linear"
         ] = "linear",
@@ -81,6 +88,7 @@ class FractionalShift(
         random_state: Optional[int] = None,
     ):
         self.shift = shift
+        self.min_shift = min_shift
         self.padding_mode = padding_mode
         self.pad_value = pad_value
         self.random_state = random_state
@@ -104,10 +112,17 @@ class FractionalShift(
         Raises
         ------
         ValueError
-            If X is not a 2D array or contains non-finite values.
+            If X is not a 2D array or contains non-finite values, or if
+            `min_shift` is greater than `shift`.
         """
         # Validate the input parameters
         self._validate_params()
+
+        if self.min_shift is not None and self.min_shift > self.shift:
+            raise ValueError(
+                f"min_shift ({self.min_shift}) must be smaller than or equal "
+                f"to shift ({self.shift})."
+            )
 
         X = validate_data(
             self, X, y="no_validation", ensure_2d=True, reset=True, dtype=np.float64
@@ -150,7 +165,12 @@ class FractionalShift(
 
     def _shift_signal(self, x: np.ndarray) -> np.ndarray:
         n = len(x)
-        shift = self._rng.uniform(-self.shift, self.shift)
+        if self.min_shift is not None:
+            mag = self._rng.uniform(self.min_shift, self.shift)
+            sign = self._rng.choice([-1.0, 1.0])
+            shift = sign * mag
+        else:
+            shift = self._rng.uniform(-self.shift, self.shift)
         indices = np.arange(n)
         shifted_indices = indices + shift
 

--- a/tests/augmentation/test_fractional_shift.py
+++ b/tests/augmentation/test_fractional_shift.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from sklearn.utils.estimator_checks import check_estimator
 
 from chemotools.augmentation import FractionalShift
@@ -116,3 +117,73 @@ def test_fractional_shift_linear():
     assert spectrum_left_shifted[0][4] == 4.623620356542087
     assert spectrum_right_shifted[0][-1] == 11.0
     assert spectrum_left_shifted[0][0] == 0
+
+
+def test_fractional_shift_min_shift():
+    # Arrange
+    # A linear ramp combined with 'linear' padding guarantees that the
+    # value-delta at every point equals exactly the applied index shift,
+    # which lets us assert directly on the shift magnitude.
+    spectrum = np.array([[1, 2, 3, 4, 5, 6, 7, 8, 9]])
+    min_shift = 0.5
+    shift = 1.0
+
+    seen_signs = set()
+    for random_state in range(50):
+        transformer = FractionalShift(
+            shift=shift,
+            min_shift=min_shift,
+            padding_mode="linear",
+            random_state=random_state,
+        )
+
+        # Act
+        shifted_spectrum = transformer.fit_transform(spectrum)
+        delta = shifted_spectrum[0] - spectrum[0]
+        delta = delta[1:-1]  # Ignore edge points affected by padding
+
+        # Assert: on the interior (unaffected by edge padding for |shift| <= 1)
+        # the applied shift is uniform and its magnitude stays within
+        # [min_shift, shift].
+        np.testing.assert_allclose(delta, delta[0])  # All deltas should be the same
+        assert min_shift - 1e-9 <= np.abs(delta[0]) <= shift + 1e-9, (
+            f"Shift magnitude {np.abs(delta[0])} not in [{min_shift}, {shift}]"
+        )
+        seen_signs.add(np.sign(delta[0]))
+
+    # Both shift directions should be sampled.
+    assert seen_signs == {-1.0, 1.0}
+
+
+def test_fractional_shift_min_shift_none_matches_full_range():
+    # Arrange
+    # With min_shift=None the behaviour must match drawing from [-shift, shift].
+    spectrum = np.array([[1, 2, 3, 4, 5, 6, 7, 8, 9]])
+    transformer = FractionalShift(
+        shift=1.0,
+        min_shift=None,
+        padding_mode="linear",
+        random_state=42,
+    )
+    reference = FractionalShift(
+        shift=1.0,
+        padding_mode="linear",
+        random_state=42,
+    )
+
+    # Act
+    shifted = transformer.fit_transform(spectrum)
+    expected = reference.fit_transform(spectrum)
+
+    # Assert
+    np.testing.assert_allclose(shifted, expected)
+
+
+def test_fractional_shift_min_shift_greater_than_shift_raises():
+    # Arrange
+    spectrum = np.array([[1, 2, 3, 4, 5, 6, 7, 8, 9]])
+    transformer = FractionalShift(shift=1.0, min_shift=2.0)
+
+    # Act & Assert
+    with pytest.raises(ValueError):
+        transformer.fit(spectrum)


### PR DESCRIPTION
## Summary

Implements `min_shift` parameter for `FractionalShift` as described in #284. Includes tests.


## Closes

Closes #284

## Type of change

<!-- Mark all that apply -->
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Tests only
- [ ] CI / DevOps / tooling
- [ ] Dependency update
- [ ] Breaking change

## What changed?

<!-- Describe the implementation at a reviewable level. -->
- Implemented `min_shift` parameter for `FractionalShift`
- Added tests
- 

## What did NOT change?

Changes are backwards-compatible (`min_shift` defaults to `None`).

## API and compatibility impact

- [ ] No public API changes
- [ ] Public API added
- [x] Public API changed
- [ ] Deprecation introduced
- [ ] Breaking change introduced

### Notes
- scikit-learn API compatibility:
- Affected modules/classes/functions: `test_fractional_shift.py`, `_fractional_shift.py`
- Backward compatibility considerations: backwards-compatible

## Validation

- [x] `task format-check`
- [x] `task lint`
- [x] `task spelling`
- [x] `task type-check`
- [x] `task test`
- [x] `task coverage`
- [ ] `task test:matrix`
- [x] `task docs:check`
- [x] `task build`

### Validation notes
<!-- Mention anything intentionally skipped and why -->
- 

## Tests

<!-- Describe the tests added or updated -->
- [x] Added new tests
- [ ] Updated existing tests
- [ ] No tests added because this PR only changes docs / CI / metadata

### Test coverage details
- Relevant test files: `test_fractional_shift.py`
- Edge cases covered: `min_shift > shift` raises `ValueError`
- Numerical / estimator behavior checked:

## Documentation

- [ ] Docs updated
- [x] Docstrings updated
- [ ] No docs update needed

### Documentation notes
<!-- Mention examples, API docs, tutorials, or user-facing docs touched -->
- 

## Dependency / build / CI impact

<!-- Complete if relevant -->
- [x] No dependency changes
- [ ] Runtime dependency change
- [ ] Dev dependency change
- [ ] GitHub Actions / CI changed
- [ ] Build/release process changed

### Notes
- 

## Reviewer focus

<!-- Tell reviewers where to spend time -->
Please focus on:
- 
- 

## Screenshots / logs / benchmark output

<!-- Optional but encouraged for docs, CI, performance, or UX-related changes -->
<details>
<summary>Details</summary>
</details>

```text
Paste logs, benchmark numbers, or screenshots description here
```

## Checklist
- [x] I linked the relevant issue(s) or explained why none exists
- [x] I kept this PR scoped to a single purpose
- [x] I added or updated tests where appropriate
- [x] I updated documentation where appropriate
- [x] I verified the change locally using the relevant tasks above
- [x] I considered backward compatibility and public API impact
- [x] I am ready for review