### PR TITLE
283 fix(discovery): don't crash when an optional dependency (e.g. matplotlib) is missing

### DIFF
--- a/chemotools/utils/discovery.py
+++ b/chemotools/utils/discovery.py
@@ -51,7 +51,7 @@ def _iter_chemotools_modules():
         except ImportError as exc:
             warnings.warn(
                 f"Skipping '{module_name}' during discovery: {exc}",
-                stacklevel=2,
+                stacklevel=3,
             )
 
 

--- a/chemotools/utils/discovery.py
+++ b/chemotools/utils/discovery.py
@@ -7,7 +7,6 @@ objects (i.e. estimators, displays, functions) from the `chemotools` package.
 
 import inspect
 import pkgutil
-import sys
 import warnings
 from importlib import import_module
 from operator import itemgetter
@@ -36,10 +35,6 @@ def _iter_chemotools_modules():
     need the affected submodule.
     """
     root = str(Path(__file__).parent.parent)  # chemotools package root
-    # Ensure chemotools is importable
-    if root not in sys.path:
-        sys.path.insert(0, root)
-
     for _, module_name, _ in pkgutil.walk_packages(path=[root], prefix="chemotools."):
         module_parts = module_name.split(".")
         # Skip ignored modules and any submodules of datasets

--- a/chemotools/utils/discovery.py
+++ b/chemotools/utils/discovery.py
@@ -8,6 +8,7 @@ objects (i.e. estimators, displays, functions) from the `chemotools` package.
 import inspect
 import pkgutil
 import sys
+import warnings
 from importlib import import_module
 from operator import itemgetter
 from pathlib import Path
@@ -24,6 +25,34 @@ from sklearn.feature_selection import SelectorMixin
 from sklearn.utils._testing import ignore_warnings
 
 _MODULE_TO_IGNORE = {"tests", "utils", "datasets"}
+
+
+def _iter_chemotools_modules():
+    """Yield importable chemotools submodules.
+
+    Submodules that fail to import (e.g. because an optional dependency such
+    as matplotlib is not installed) are skipped with a warning instead of
+    propagating the error, so discovery keeps working for callers who don't
+    need the affected submodule.
+    """
+    root = str(Path(__file__).parent.parent)  # chemotools package root
+    # Ensure chemotools is importable
+    if root not in sys.path:
+        sys.path.insert(0, root)
+
+    for _, module_name, _ in pkgutil.walk_packages(path=[root], prefix="chemotools."):
+        module_parts = module_name.split(".")
+        # Skip ignored modules and any submodules of datasets
+        if any(part in _MODULE_TO_IGNORE for part in module_parts):
+            continue
+
+        try:
+            yield import_module(module_name)
+        except ImportError as exc:
+            warnings.warn(
+                f"Skipping '{module_name}' during discovery: {exc}",
+                stacklevel=2,
+            )
 
 
 def all_estimators(type_filter=None):
@@ -62,22 +91,9 @@ def all_estimators(type_filter=None):
         return bool(getattr(c, "__abstractmethods__", False))
 
     all_classes = []
-    root = str(Path(__file__).parent.parent)  # chemotools package root
-    # Ensure chemotools is importable
-    if root not in sys.path:
-        sys.path.insert(0, root)
 
     with ignore_warnings(category=FutureWarning):
-        for _, module_name, _ in pkgutil.walk_packages(
-            path=[root], prefix="chemotools."
-        ):
-            module_parts = module_name.split(".")
-            # Skip ignored modules and any submodules of datasets
-
-            if any(part in _MODULE_TO_IGNORE for part in module_parts):
-                continue
-
-            module = import_module(module_name)
+        for module in _iter_chemotools_modules():
             classes = inspect.getmembers(module, inspect.isclass)
             # Only classes defined in this module
             classes = [
@@ -143,17 +159,10 @@ def all_displays():
     >>> displays = all_displays()
     """
     all_classes = []
-    root = str(Path(__file__).parent.parent)  # chemotools package
     # Ignore deprecation warnings triggered at import time and from walking
     # packages
     with ignore_warnings(category=FutureWarning):
-        for _, module_name, _ in pkgutil.walk_packages(
-            path=[root], prefix="chemotools."
-        ):
-            module_parts = module_name.split(".")
-            if any(part in _MODULE_TO_IGNORE for part in module_parts):
-                continue
-            module = import_module(module_name)
+        for module in _iter_chemotools_modules():
             classes = inspect.getmembers(module, inspect.isclass)
             classes = [
                 (name, display_class)
@@ -194,18 +203,10 @@ def all_functions():
     >>> functions = all_functions()
     """
     all_functions = []
-    root = str(Path(__file__).parent.parent)  # chemotools package
     # Ignore deprecation warnings triggered at import time and from walking
     # packages
     with ignore_warnings(category=FutureWarning):
-        for _, module_name, _ in pkgutil.walk_packages(
-            path=[root], prefix="chemotools."
-        ):
-            module_parts = module_name.split(".")
-            if any(part in _MODULE_TO_IGNORE for part in module_parts):
-                continue
-
-            module = import_module(module_name)
+        for module in _iter_chemotools_modules():
             functions = inspect.getmembers(module, _is_checked_function)
             functions = [(func.__name__, func) for name, func in functions]
             all_functions.extend(functions)

--- a/tests/utils/test_discovery.py
+++ b/tests/utils/test_discovery.py
@@ -1,5 +1,6 @@
 import pytest
 
+from chemotools.utils import discovery as discovery_module
 from chemotools.utils.discovery import all_displays, all_estimators, all_functions
 
 
@@ -62,3 +63,33 @@ def test_all_functions_returns_list_of_tuples():
     # Check no duplicate names
     names = [name for name, _ in result]
     assert len(names) == len(set(names))
+
+
+@pytest.mark.parametrize(
+    "unimportable_module", ["chemotools.plotting", "chemotools.inspector"]
+)
+@pytest.mark.parametrize(
+    "discover", [all_estimators, all_displays, all_functions], ids=lambda f: f.__name__
+)
+def test_discovery_skips_module_with_missing_optional_dependency(
+    monkeypatch, unimportable_module, discover
+):
+    """Reproduces #283: a submodule whose package raises ImportError at
+    import time (e.g. because matplotlib/the `viz` extra isn't installed)
+    must be skipped with a warning instead of crashing discovery."""
+    real_import_module = discovery_module.import_module
+
+    def fake_import_module(name):
+        if name == unimportable_module:
+            raise ImportError(
+                f"'{name}' requires the optional dependency 'matplotlib'. "
+                "Install it with: pip install chemotools[viz]"
+            )
+        return real_import_module(name)
+
+    monkeypatch.setattr(discovery_module, "import_module", fake_import_module)
+
+    with pytest.warns(UserWarning, match=unimportable_module):
+        result = discover()
+
+    assert isinstance(result, list)

--- a/tests/utils/test_discovery.py
+++ b/tests/utils/test_discovery.py
@@ -79,13 +79,13 @@ def test_discovery_skips_module_with_missing_optional_dependency(
     must be skipped with a warning instead of crashing discovery."""
     real_import_module = discovery_module.import_module
 
-    def fake_import_module(name):
+    def fake_import_module(name, package=None):
         if name == unimportable_module:
             raise ImportError(
                 f"'{name}' requires the optional dependency 'matplotlib'. "
                 "Install it with: pip install chemotools[viz]"
             )
-        return real_import_module(name)
+        return real_import_module(name, package)
 
     monkeypatch.setattr(discovery_module, "import_module", fake_import_module)
 


### PR DESCRIPTION
## Summary

`all_estimators()`, `all_displays()`, and `all_functions()` crashed with an uncaught `ImportError` whenever matplotlib (the `viz` extra) wasn't installed, since `chemotools.plotting`/`chemotools.inspector` fail to import without it and discovery had no handling for that.

This is a fast fix for the immediate crash, but it's also worth keeping as a general safeguard: any future subpackage with an optional dependency will now degrade gracefully instead of breaking discovery for everyone.

Fixes #283.

## Changes

- Extract a shared `_iter_chemotools_modules()` generator (used by all three public functions) that catches `ImportError` per submodule and emits a `UserWarning` naming the skipped module instead of propagating, a permanent safeguard, not just a one-off patch, so any future optional-dependency-gated subpackage degrades gracefully instead of crashing discovery.
- Warning is raised with `stacklevel=3` so it's attributed to the caller's own call site (e.g. their `all_estimators()` call) rather than to internal discovery-loop plumbing.
- Add a regression test (`test_discovery_skips_module_with_missing_optional_dependency`) that fakes an `ImportError` from `chemotools.plotting`/`chemotools.inspector` to simulate matplotlib being absent, and asserts each discovery function still returns a list and warns instead of crashing.
