### PR TITLE
Add ScatterShift augmentation (forward EMSC model)

### DIFF
--- a/chemotools/augmentation/__init__.py
+++ b/chemotools/augmentation/__init__.py
@@ -3,6 +3,7 @@ from ._baseline_shift import BaselineShift
 from ._fractional_shift import FractionalShift
 from ._gaussian_broadening import GaussianBroadening
 from ._index_shift import IndexShift
+from ._scatter_shift import ScatterShift
 from ._spectrum_scale import SpectrumScale
 
 __all__ = [
@@ -11,5 +12,6 @@ __all__ = [
     "FractionalShift",
     "GaussianBroadening",
     "IndexShift",
+    "ScatterShift",
     "SpectrumScale",
 ]

--- a/chemotools/augmentation/_scatter_shift.py
+++ b/chemotools/augmentation/_scatter_shift.py
@@ -150,7 +150,7 @@ class ScatterShift(DocLinkMixin, TransformerMixin, OneToOneFeatureMixin, BaseEst
         # Build the polynomial baseline basis on normalized wavelength indices.
         # This mirrors the EMSC design matrix so the augmentation is the forward
         # counterpart of ExtendedMultiplicativeScatterCorrection.
-        x_indices = np.linspace(-1, 1, self.n_features_in_)
+        x_indices = np.linspace(-1, 1, X.shape[1])
         self.polynomial_basis_ = np.vander(x_indices, N=self.order + 1, increasing=True)
 
         # Instantiate the random number generator

--- a/chemotools/augmentation/_scatter_shift.py
+++ b/chemotools/augmentation/_scatter_shift.py
@@ -5,8 +5,8 @@ random polynomial baseline, following the forward Extended Multiplicative Scatte
 Correction (EMSC) model.
 """
 
-
-#<CONTRIBUTOR NAME -- Prabesh Joshi>
+# Authors: Prabesh Joshi
+# License: MIT
 
 from numbers import Integral
 from typing import Optional
@@ -151,9 +151,7 @@ class ScatterShift(DocLinkMixin, TransformerMixin, OneToOneFeatureMixin, BaseEst
         # This mirrors the EMSC design matrix so the augmentation is the forward
         # counterpart of ExtendedMultiplicativeScatterCorrection.
         x_indices = np.linspace(-1, 1, self.n_features_in_)
-        self.polynomial_basis_ = np.vander(
-            x_indices, N=self.order + 1, increasing=True
-        )
+        self.polynomial_basis_ = np.vander(x_indices, N=self.order + 1, increasing=True)
 
         # Instantiate the random number generator
         self._rng = check_random_state(self.random_state)

--- a/chemotools/augmentation/_scatter_shift.py
+++ b/chemotools/augmentation/_scatter_shift.py
@@ -1,0 +1,213 @@
+"""
+The :mod:`chemotools.augmentation._scatter_shift` module implements the ScatterShift
+transformer to augment spectral data with random multiplicative scatter and a
+random polynomial baseline, following the forward Extended Multiplicative Scatter
+Correction (EMSC) model.
+"""
+
+
+#<CONTRIBUTOR NAME -- Prabesh Joshi>
+
+from numbers import Integral
+from typing import Optional
+
+import numpy as np
+from sklearn.base import BaseEstimator, OneToOneFeatureMixin, TransformerMixin
+from sklearn.utils import check_random_state
+from sklearn.utils._param_validation import Interval, Real
+from sklearn.utils.validation import check_is_fitted, validate_data
+
+from chemotools._doc_mixin import DocLinkMixin
+
+
+class ScatterShift(DocLinkMixin, TransformerMixin, OneToOneFeatureMixin, BaseEstimator):
+    """Augment spectra with random multiplicative scatter and a polynomial baseline.
+
+    This transformer applies the *forward* Extended Multiplicative Scatter
+    Correction (EMSC) model to each spectrum, injecting the same scatter
+    structure that :class:`~chemotools.scatter.ExtendedMultiplicativeScatterCorrection`
+    is designed to remove. It is intended for data augmentation: generating
+    synthetic spectra that mimic the multiplicative scaling and wavelength-
+    dependent baseline drift introduced by physical light scatter (e.g.,
+    differences in particle size, path length, or packing density).
+
+    Unlike chaining :class:`~chemotools.augmentation.SpectrumScale` (a scalar
+    multiplicative factor) with :class:`~chemotools.augmentation.BaselineShift`
+    (a constant offset), this transformer can introduce a *wavelength-dependent*
+    polynomial baseline, which is the characteristic signature of scatter that
+    EMSC models.
+
+    At default parameters (``multiplicative_scale=0.0`` and
+    ``additive_scale=0.0``) the transformer is the identity.
+
+    Parameters
+    ----------
+    order : int, default=2
+        The order of the random polynomial baseline. 0 is a constant offset,
+        1 is linear, 2 is quadratic, etc. Matches the ``order`` parameter of
+        :class:`~chemotools.scatter.ExtendedMultiplicativeScatterCorrection`.
+
+    multiplicative_scale : float, default=0.0
+        Range of the uniform distribution used to draw the multiplicative
+        scatter factor ``m``, sampled per spectrum from
+        ``U(1 - multiplicative_scale, 1 + multiplicative_scale)``.
+
+    additive_scale : float, default=0.0
+        Range of the uniform distribution used to draw each polynomial baseline
+        coefficient, sampled per spectrum from
+        ``U(-additive_scale, additive_scale)``.
+
+    random_state : int, default=None
+        The random state to use for the random number generator.
+
+    Attributes
+    ----------
+    polynomial_basis_ : ndarray of shape (n_features, order + 1)
+        The polynomial design matrix evaluated on normalized wavelength indices,
+        built identically to the EMSC baseline basis.
+
+    n_features_in_ : int
+        Number of features seen during :meth:`fit`.
+
+    Notes
+    -----
+    The forward model applied to each spectrum :math:`x` is:
+
+    .. math::
+        x_{aug} = m \\cdot x + \\sum_{i=0}^{order} c_i \\lambda^i
+
+    where :math:`m` is the multiplicative scatter factor, :math:`c_i` are the
+    random polynomial baseline coefficients, and :math:`\\lambda` are the
+    wavelength indices normalized to the interval :math:`[-1, 1]`. This is the
+    inverse of the EMSC correction model.
+
+    References
+    ----------
+    .. [1] Nils Kristian Afseth, Achim Kohler. "Extended multiplicative signal
+       correction in vibrational spectroscopy, a tutorial,"
+       Chemometrics and Intelligent Laboratory Systems, 2012.
+
+    Examples
+    --------
+    >>> from chemotools.augmentation import ScatterShift
+    >>> from chemotools.datasets import load_fermentation_train
+    >>> # Load sample data
+    >>> X, _ = load_fermentation_train()
+    >>> # Instantiate the transformer
+    >>> transformer = ScatterShift(
+    ...     order=2, multiplicative_scale=0.05, additive_scale=0.01, random_state=42
+    ... )
+    >>> transformer.fit(X)
+    ScatterShift()
+    >>> # Generate scatter-augmented data
+    >>> X_augmented = transformer.transform(X)
+    """
+
+    _parameter_constraints: dict = {
+        "order": [Interval(Integral, 0, None, closed="left")],
+        "multiplicative_scale": [Interval(Real, 0, None, closed="both")],
+        "additive_scale": [Interval(Real, 0, None, closed="both")],
+        "random_state": [None, int, np.random.RandomState],
+    }
+
+    def __init__(
+        self,
+        order: int = 2,
+        multiplicative_scale: float = 0.0,
+        additive_scale: float = 0.0,
+        random_state: Optional[int] = None,
+    ):
+        self.order = order
+        self.multiplicative_scale = multiplicative_scale
+        self.additive_scale = additive_scale
+        self.random_state = random_state
+
+    def fit(self, X: np.ndarray, y=None) -> "ScatterShift":
+        """
+        Fit the transformer to the input data.
+
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_samples, n_features)
+            The input data to fit the transformer to.
+
+        y : None
+            Ignored.
+
+        Returns
+        -------
+        self : ScatterShift
+            The fitted transformer.
+        """
+        # Validate the input parameters
+        self._validate_params()
+
+        # Check that X is a 2D array and has only finite values
+        X = validate_data(
+            self, X, y="no_validation", ensure_2d=True, reset=True, dtype=np.float64
+        )
+
+        # Build the polynomial baseline basis on normalized wavelength indices.
+        # This mirrors the EMSC design matrix so the augmentation is the forward
+        # counterpart of ExtendedMultiplicativeScatterCorrection.
+        x_indices = np.linspace(-1, 1, self.n_features_in_)
+        self.polynomial_basis_ = np.vander(
+            x_indices, N=self.order + 1, increasing=True
+        )
+
+        # Instantiate the random number generator
+        self._rng = check_random_state(self.random_state)
+
+        return self
+
+    def transform(self, X: np.ndarray, y=None) -> np.ndarray:
+        """
+        Transform the input data by applying random multiplicative scatter and a
+        random polynomial baseline.
+
+        Parameters
+        ----------
+        X : np.ndarray of shape (n_samples, n_features)
+            The input data to transform.
+
+        y : None
+            Ignored.
+
+        Returns
+        -------
+        X_transformed : np.ndarray of shape (n_samples, n_features)
+            The transformed data.
+        """
+        # Check that the estimator is fitted
+        check_is_fitted(self, "n_features_in_")
+
+        # Check that X is a 2D array and has only finite values
+        X_ = validate_data(
+            self,
+            X,
+            y="no_validation",
+            ensure_2d=True,
+            copy=True,
+            reset=False,
+            dtype=np.float64,
+        )
+
+        n_samples = X_.shape[0]
+
+        # Draw one multiplicative factor per spectrum: m ~ U(1 - s, 1 + s)
+        multiplicative_factors = self._rng.uniform(
+            low=1 - self.multiplicative_scale,
+            high=1 + self.multiplicative_scale,
+            size=(n_samples, 1),
+        )
+
+        # Draw polynomial baseline coefficients per spectrum: c_i ~ U(-s, s)
+        baseline_coefficients = self._rng.uniform(
+            low=-self.additive_scale,
+            high=self.additive_scale,
+            size=(n_samples, self.order + 1),
+        )
+
+        # Forward EMSC model: x_aug = m * x + polynomial baseline
+        baselines = baseline_coefficients @ self.polynomial_basis_.T
+        return multiplicative_factors * X_ + baselines

--- a/tests/augmentation/test_scatter_shift.py
+++ b/tests/augmentation/test_scatter_shift.py
@@ -68,9 +68,12 @@ def test_scatter_shift_reproducible():
     # Arrange
     rng = np.random.default_rng(1)
     spectra = rng.normal(size=(4, 60))
-    params = dict(
-        order=2, multiplicative_scale=0.05, additive_scale=0.02, random_state=7
-    )
+    params = {
+        "order": 2,
+        "multiplicative_scale": 0.05,
+        "additive_scale": 0.02,
+        "random_state": 7,
+    }
 
     # Act
     first = ScatterShift(**params).fit_transform(spectra)
@@ -98,4 +101,7 @@ def test_scatter_shift_basis_matches_emsc():
     # And EMSC at the same order builds the same polynomial block, confirming the
     # augmenter is the forward counterpart of the correction
     emsc = ExtendedMultiplicativeScatterCorrection(order=order).fit(spectra)
-    assert np.allclose(emsc.A_[:, : order + 1], transformer.polynomial_basis_, atol=1e-12)
+    assert emsc.A_[:, : order + 1].shape == transformer.polynomial_basis_.shape
+    assert np.allclose(
+        emsc.A_[:, : order + 1], transformer.polynomial_basis_, atol=1e-12
+    )

--- a/tests/augmentation/test_scatter_shift.py
+++ b/tests/augmentation/test_scatter_shift.py
@@ -1,0 +1,101 @@
+import numpy as np
+from sklearn.utils.estimator_checks import check_estimator
+
+from chemotools.augmentation import ScatterShift
+from chemotools.scatter import ExtendedMultiplicativeScatterCorrection
+
+
+# Test compliance with scikit-learn
+def test_compliance_scatter_shift():
+    # Arrange
+    transformer = ScatterShift()
+    # Act & Assert
+    check_estimator(transformer)
+
+
+# Test that default parameters leave the data unchanged (identity)
+def test_scatter_shift_identity_at_defaults():
+    # Arrange
+    rng = np.random.default_rng(0)
+    spectra = rng.normal(size=(5, 50))
+    transformer = ScatterShift(random_state=42)
+
+    # Act
+    spectra_augmented = transformer.fit_transform(spectra)
+
+    # Assert
+    assert spectra.shape == spectra_augmented.shape
+    assert np.allclose(spectra, spectra_augmented, atol=1e-8)
+
+
+# Test that a multiplicative-only shift scales each spectrum by a constant factor
+def test_scatter_shift_multiplicative_only():
+    # Arrange
+    spectrum = np.ones(100).reshape(1, -1)
+    transformer = ScatterShift(
+        order=0, multiplicative_scale=0.1, additive_scale=0.0, random_state=42
+    )
+
+    # Act
+    augmented = transformer.fit_transform(spectrum)
+
+    # Assert: a flat spectrum stays flat under a pure multiplicative factor
+    assert augmented.shape == spectrum.shape
+    assert np.isclose(np.std(augmented[0]), 0.0, atol=1e-8)
+    # The multiplicative factor must lie within [1 - scale, 1 + scale]
+    assert 0.9 <= augmented[0, 0] <= 1.1
+
+
+# Test that an additive polynomial baseline introduces wavelength-dependent structure
+def test_scatter_shift_polynomial_baseline():
+    # Arrange
+    spectrum = np.ones(100).reshape(1, -1)
+    transformer = ScatterShift(
+        order=2, multiplicative_scale=0.0, additive_scale=0.5, random_state=42
+    )
+
+    # Act
+    augmented = transformer.fit_transform(spectrum)
+
+    # Assert: a non-zero order baseline introduces curvature (non-constant offset),
+    # which BaselineShift (constant only) cannot produce
+    assert augmented.shape == spectrum.shape
+    assert np.std(augmented[0]) > 0.0
+
+
+# Test reproducibility with a fixed random_state
+def test_scatter_shift_reproducible():
+    # Arrange
+    rng = np.random.default_rng(1)
+    spectra = rng.normal(size=(4, 60))
+    params = dict(
+        order=2, multiplicative_scale=0.05, additive_scale=0.02, random_state=7
+    )
+
+    # Act
+    first = ScatterShift(**params).fit_transform(spectra)
+    second = ScatterShift(**params).fit_transform(spectra)
+
+    # Assert
+    assert np.allclose(first, second, atol=1e-12)
+
+
+# Test that the polynomial basis matches the EMSC design-matrix construction
+def test_scatter_shift_basis_matches_emsc():
+    # Arrange
+    n_features = 75
+    order = 3
+    spectra = np.ones((3, n_features))
+    transformer = ScatterShift(order=order).fit(spectra)
+
+    # Reconstruct the EMSC polynomial basis independently
+    x_indices = np.linspace(-1, 1, n_features)
+    expected_basis = np.vander(x_indices, N=order + 1, increasing=True)
+
+    # Assert: augmentation basis is identical to the EMSC baseline basis
+    assert np.allclose(transformer.polynomial_basis_, expected_basis, atol=1e-12)
+
+    # And EMSC at the same order builds the same polynomial block, confirming the
+    # augmenter is the forward counterpart of the correction
+    emsc = ExtendedMultiplicativeScatterCorrection(order=order).fit(spectra)
+    assert emsc.A_[:, : order + 1].shape == transformer.polynomial_basis_.shape

--- a/tests/augmentation/test_scatter_shift.py
+++ b/tests/augmentation/test_scatter_shift.py
@@ -98,4 +98,4 @@ def test_scatter_shift_basis_matches_emsc():
     # And EMSC at the same order builds the same polynomial block, confirming the
     # augmenter is the forward counterpart of the correction
     emsc = ExtendedMultiplicativeScatterCorrection(order=order).fit(spectra)
-    assert emsc.A_[:, : order + 1].shape == transformer.polynomial_basis_.shape
+    assert np.allclose(emsc.A_[:, : order + 1], transformer.polynomial_basis_, atol=1e-12)


### PR DESCRIPTION
## Summary
- Adds `chemotools.augmentation.ScatterShift`, a transformer that injects random
  multiplicative scatter and a random polynomial baseline using the forward
  Extended Multiplicative Scatter Correction (EMSC) model:
  `x_aug = m·x + Σ cᵢ·λⁱ`.

## Why is this change needed?
- The augmentation module covers additive noise (`AddNoise`), a constant baseline
  (`BaselineShift`), a scalar multiplicative factor (`SpectrumScale`), axis shifts,
  and peak broadening, but has no augmenter for multiplicative scatter combined
  with a wavelength-dependent baseline: the dominant physical scatter signature
  in NIR/vibrational spectra. `ScatterShift` fills that gap and is the forward
  counterpart of the existing `ExtendedMultiplicativeScatterCorrection`: augment
  with `ScatterShift`, correct with EMSC.

## Closes
- Closes #292

## Related issues
- 

## Type of change
- [x] New feature
- [x] Tests only

## What changed?
- Added `chemotools/augmentation/_scatter_shift.py` implementing `ScatterShift`.
- Registered `ScatterShift` in `chemotools/augmentation/__init__.py` (import + `__all__`).
- Added `tests/augmentation/test_scatter_shift.py`.

## What did NOT change?
- No changes to `chemotools.scatter` (EMSC/MSC correctors are unchanged).
- No changes to any other augmentation transformer.
- No docs page updated yet (see Documentation notes below).

## API and compatibility impact
- [x] Public API added
### Notes
- scikit-learn API compatibility: `ScatterShift` inherits `DocLinkMixin,
  TransformerMixin, OneToOneFeatureMixin, BaseEstimator`, uses
  `_parameter_constraints` for all four parameters, and passes
  `check_estimator()` at default parameters (identity transform when
  `multiplicative_scale=0.0` and `additive_scale=0.0`).
- Affected modules/classes/functions: `chemotools.augmentation` (new class
  `ScatterShift`); `chemotools/augmentation/__init__.py` (new export).
- Backward compatibility considerations: purely additive change, no existing
  public API modified.

## Validation
<!-- none checked: not yet run via the project's own `task` commands -->
### Validation notes
- Verified locally (outside `task`) via `ruff format --check`, `ruff check`, and
  `python -m pytest tests/augmentation/test_scatter_shift.py -v` : all passing,
  6/6 tests, no lint or format issues. Have not yet run the full `task check` /
  `task test:matrix` suite; deferring to CI for the dependency-floor and
  multi-version matrix.

## Tests
- [x] Added new tests
### Test coverage details
- Relevant test files: `tests/augmentation/test_scatter_shift.py`
- Edge cases covered: identity behavior at default parameters, multiplicative-only
  case (`order=0`), polynomial-baseline case (`order≥1`), reproducibility under a
  fixed `random_state`, and an explicit check that the internal polynomial basis
  is identical to `ExtendedMultiplicativeScatterCorrection`'s design matrix.
- Numerical / estimator behavior checked: `check_estimator()` compliance;
  round-trip sanity (augmenting then EMSC-correcting recovers the original signal),
  checked manually, not asserted as a formal test.

## Documentation
- [ ] Docs updated
- [x] Docstrings updated
### Documentation notes
- `ScatterShift` has a full numpydoc docstring (model equation, EMSC
  cross-reference, Afseth & Kohler 2012 reference, runnable example), but the
  augmentation methods page (`methods/augmentation_methods.html`) is not yet
  updated. Happy to add an entry if you point me to the right file/format.

## Dependency / build / CI impact
- [x] No dependency changes

## Reviewer focus
Please focus on:
- Whether the forward-model framing (and reuse of the EMSC polynomial basis) is
  the right approach, versus a different parameterization.

## Checklist
- [x] I linked the relevant issue(s) or explained why none exists
- [x] I kept this PR scoped to a single purpose
- [x] I added or updated tests where appropriate
- [ ] I updated documentation where appropriate
- [ ] I verified the change locally using the relevant tasks above
- [x] I considered backward compatibility and public API impact
- [x] I am ready for review